### PR TITLE
Add api subcommand & Add makefile in project root directory to build project easily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: default
+default:
+	@cd src && $(MAKE) default
+
+.PHONY: linux-arm
+linux-arm:
+	@cd src && $(MAKE) linux-arm
+
+#windows 64bint
+.PHONY: win
+win:
+	@cd src && $(MAKE) win
+
+#windows 32bit
+.PHONY: win86
+win86:
+	@cd src && $(MAKE) win86
+
+.PHONY: mac
+mac:
+	@cd src && $(MAKE) mac
+
+.PHONY: mac-arm
+mac-arm:
+	@cd src && $(MAKE) mac-arm
+
+.PHONY: clean
+clean:
+	@cd src && $(MAKE) clean

--- a/src/cmd/apicall/root.go
+++ b/src/cmd/apicall/root.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/mc-admin-cli/mcc/src/cmd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -365,5 +366,5 @@ func init() {
 	apiCmd.PersistentFlags().StringVarP(&sendData, "data", "d", "", "Data to send to the server")
 	apiCmd.PersistentFlags().StringVarP(&fileData, "file", "f", "", "Data to send to the server from file(not yet support)")
 
-	// cmd.RootCmd.AddCommand(apiCmd)
+	cmd.RootCmd.AddCommand(apiCmd)
 }


### PR DESCRIPTION
# 작업내용
- mcc 의 subcommand 로 하위 서브 시스템을 호출하는 api 커맨드 추가
- 자동화된 프로젝트 빌드 프로세스를 위한 makefile 작성
  - src 하위 makefile 을 호출
