### PR TITLE
Add initialization and configuration scripts for MC-IAM-Manager

### DIFF
--- a/bin/1iam_manager_set_mode.sh
+++ b/bin/1iam_manager_set_mode.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+# MC-IAM-Manager 모드 설정 스크립트
+
+# 스크립트 시작 시 현재 위치 저장
+ORIGINAL_DIR="$(pwd)"
+
+echo "=========================================="
+echo "MC-IAM-Manager Configuration Mode Selection"
+echo "=========================================="
+echo ""
+echo "MC-IAM-Manager는 두 가지 모드로 구성할 수 있습니다:"
+echo ""
+echo "[개발자모드-로컬인증]"
+echo "  - Self-signed 인증서 사용"
+echo "  - 로컬 개발 환경에 최적화"
+echo "  - hosts 파일에 도메인 추가"
+echo "  - 빠른 설정 및 테스트 가능"
+echo ""
+echo "[프로덕션모드-CA인증]"
+echo "  - Let's Encrypt CA 인증서 사용"
+echo "  - 실제 도메인에서 사용"
+echo "  - 보안 인증서 기반 HTTPS"
+echo "  - 프로덕션 환경에 적합"
+echo ""
+echo "=========================================="
+
+# 사용자 선택 입력
+while true; do
+    echo -n "어떤 모드로 구성하시겠습니까? (1: 개발자모드, 2: 프로덕션모드): "
+    read -r choice
+    
+    case $choice in
+        1)
+            echo ""
+            echo "개발자모드-로컬인증을 선택하셨습니다."
+            echo "Self-signed 인증서를 생성하고 로컬 환경을 설정합니다..."
+            echo ""
+            
+            # 개발자 모드 스크립트 실행
+            cd ../conf/docker/conf/mc-iam-manager/ || {
+                echo "오류: mc-iam-manager 디렉토리를 찾을 수 없습니다."
+                cd "$ORIGINAL_DIR"
+                exit 1
+            }
+            
+            if [ -f "0_preset_dev.sh" ]; then
+                chmod +x 0_preset_dev.sh
+                ./0_preset_dev.sh
+                if [ $? -eq 0 ]; then
+                    echo ""
+                    echo "✓ 개발자모드 설정이 완료되었습니다."
+                    echo "이제 ./mcc infra run을 실행할 수 있습니다."
+                else
+                    echo ""
+                    echo "❌ 개발자모드 설정 중 오류가 발생했습니다."
+                    cd "$ORIGINAL_DIR"
+                    exit 1
+                fi
+            else
+                echo "오류: 0_preset_dev.sh 파일을 찾을 수 없습니다."
+                cd "$ORIGINAL_DIR"
+                exit 1
+            fi
+            
+            break
+            ;;
+        2)
+            echo ""
+            echo "프로덕션모드-CA인증을 선택하셨습니다."
+            echo "Let's Encrypt 인증서를 생성하고 프로덕션 환경을 설정합니다..."
+            echo ""
+            
+            # 프로덕션 모드: 인증서 생성
+            echo "1단계: Let's Encrypt 인증서 생성 중..."
+            
+            # 원래 위치로 돌아가서 mcc 실행
+            cd "$ORIGINAL_DIR" || {
+                echo "오류: 원래 디렉토리로 돌아갈 수 없습니다."
+                exit 1
+            }
+            
+            if [ -f "./mcc" ]; then
+                ./mcc infra run -f ../conf/docker/docker-compose.cert.yaml
+                if [ $? -eq 0 ]; then
+                    echo "✓ 인증서 생성이 완료되었습니다."
+                else
+                    echo "❌ 인증서 생성 중 오류가 발생했습니다."
+                    exit 1
+                fi
+            else
+                echo "오류: mcc 실행 파일을 찾을 수 없습니다."
+                exit 1
+            fi
+            
+            echo ""
+            echo "2단계: 프로덕션 모드 설정 중..."
+            
+            # 프로덕션 모드 스크립트 실행
+            cd ../conf/docker/conf/mc-iam-manager/ || {
+                echo "오류: mc-iam-manager 디렉토리를 찾을 수 없습니다."
+                cd "$ORIGINAL_DIR"
+                exit 1
+            }
+            
+            if [ -f "0_preset_prod.sh" ]; then
+                chmod +x 0_preset_prod.sh
+                ./0_preset_prod.sh
+                if [ $? -eq 0 ]; then
+                    echo ""
+                    echo "✓ 프로덕션모드 설정이 완료되었습니다."
+                    echo "이제 ./mcc infra run을 실행할 수 있습니다."
+                else
+                    echo ""
+                    echo "❌ 프로덕션모드 설정 중 오류가 발생했습니다."
+                    cd "$ORIGINAL_DIR"
+                    exit 1
+                fi
+            else
+                echo "오류: 0_preset_prod.sh 파일을 찾을 수 없습니다."
+                cd "$ORIGINAL_DIR"
+                exit 1
+            fi
+            
+            break
+            ;;
+        *)
+            echo "잘못된 선택입니다. 1 또는 2를 입력해주세요."
+            ;;
+    esac
+done
+
+# 모든 모드 설정 완료 후 원래 위치로 돌아가기
+cd "$ORIGINAL_DIR"
+
+echo ""
+echo "======================================================"
+echo "설정이 완료되었습니다!"
+echo "이제 ./mcc infra run을 실행하여 서비스를 시작할 수 있습니다."
+echo "======================================================"
+
+# 서비스 실행 여부 확인
+echo ""
+while true; do
+    echo -n "./mcc infra run을 실행하여 서비스를 실행하겠습니까? (y/n): "
+    read -r run_choice
+    
+    case $run_choice in
+        [Yy])
+            echo ""
+            echo "서비스를 시작합니다..."
+            echo "=========================================="
+            
+            # 원래 위치로 돌아가기
+            cd "$ORIGINAL_DIR" || {
+                echo "오류: 원래 디렉토리로 돌아갈 수 없습니다."
+                exit 1
+            }
+            
+            # mcc infra run 실행
+            if [ -f "./mcc" ]; then
+                ./mcc infra run
+            else
+                echo "오류: mcc 실행 파일을 찾을 수 없습니다."
+                exit 1
+            fi
+            break
+            ;;
+        [Nn])
+            echo ""
+            echo "서비스 실행을 건너뜁니다."
+            echo "나중에 './mcc infra run' 명령으로 서비스를 시작할 수 있습니다."
+            break
+            ;;
+        *)
+            echo "잘못된 선택입니다. y 또는 n을 입력해주세요."
+            ;;
+    esac
+done
+

--- a/bin/2iam_manager_init.sh
+++ b/bin/2iam_manager_init.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+# MC-IAM-Manager 초기화 모드 설정 스크립트
+
+# 스크립트 시작 시 현재 위치 저장
+ORIGINAL_DIR="$(pwd)"
+
+echo "=========================================="
+echo "MC-IAM-Manager Initialization"
+echo "=========================================="
+echo ""
+
+# 필수 컨테이너 상태 체크
+echo "----------------------------------------"
+echo "  Required Container Health Check"
+echo "----------------------------------------"
+echo "필수 컨테이너 상태를 확인하고 있습니다..."
+echo ""
+
+REQUIRED_CONTAINERS=("mc-iam-manager" "mc-iam-manager-db" "mc-iam-manager-kc")
+ALL_HEALTHY=true
+
+for container in "${REQUIRED_CONTAINERS[@]}"; do
+    echo -n "체크 중: $container ... "
+    
+    # 컨테이너가 존재하는지 확인
+    if ! docker ps --format "table {{.Names}}" | grep -q "^$container$"; then
+        echo "❌ 컨테이너가 실행되지 않았습니다."
+        ALL_HEALTHY=false
+        continue
+    fi
+    
+    # 컨테이너 상태 확인
+    container_status=$(docker inspect --format='{{.State.Health.Status}}' "$container" 2>/dev/null)
+    
+    if [ "$container_status" = "healthy" ]; then
+        echo "✅ 정상"
+    elif [ "$container_status" = "starting" ]; then
+        echo "⏳ 시작 중..."
+        ALL_HEALTHY=false
+    elif [ "$container_status" = "unhealthy" ]; then
+        echo "❌ 비정상"
+        ALL_HEALTHY=false
+    else
+        echo "❓ 상태 확인 불가 ($container_status)"
+        ALL_HEALTHY=false
+    fi
+done
+
+echo ""
+
+if [ "$ALL_HEALTHY" = false ]; then
+    echo "❌ 필수 컨테이너가 모두 정상 상태가 아닙니다."
+    echo "다음 컨테이너들이 정상적으로 구동된 후 다시 시도해주세요:"
+    echo "  - mc-iam-manager"
+    echo "  - mc-iam-manager-db"
+    echo "  - mc-iam-manager-kc"
+    echo ""
+    echo "컨테이너 상태 확인: docker ps"
+    echo "컨테이너 로그 확인: docker logs [컨테이너명]"
+    exit 1
+fi
+
+echo "✅ 모든 필수 컨테이너가 정상 상태입니다."
+echo "초기화를 진행할 수 있습니다..."
+echo ""
+
+echo "------------------------------------------------"
+echo "  MC-IAM-Manager Initialization Mode Selection"
+echo "------------------------------------------------"
+echo "MC-IAM-Manager 초기화는 두 가지 모드로 진행할 수 있습니다:"
+echo ""
+echo "[전체 초기화 - 자동 모드]"
+echo "  - 모든 초기화 작업이 자동으로 순차 진행"
+echo "  - 플랫폼 어드민 초기화"
+echo "  - 로그인 및 인증 토큰 발급"
+echo "  - 사전 정의된 역할 생성 (admin, operator, viewer 등)"
+echo "  - 메뉴 데이터 초기화"
+echo "  - API 리소스 데이터 초기화"
+echo "  - 프로젝트 동기화 및 워크스페이스 매핑"
+echo "  - 빠르고 편리한 일괄 설정"
+echo ""
+echo "[부분 초기화 - 수동 모드]"
+echo "  - 초기화 가능한 작업 목록을 사용자가 선택"
+echo "  - 각 단계별로 개별 실행 가능"
+echo "  - 상세한 진행 상황 확인"
+echo "  - 특정 기능만 선택적으로 초기화"
+echo "  - 문제 발생 시 단계별 디버깅 가능"
+echo ""
+echo "=============================================================="
+
+
+# 사용자 선택 입력
+while true; do
+    echo -n "어떤 초기화 모드를 선택하시겠습니까? (1: 전체 초기화, 2: 부분 초기화): "
+    read -r choice
+    
+    case $choice in
+        1)
+            echo ""
+            echo "전체 초기화-자동 모드를 선택하셨습니다."
+            echo "모든 초기화 작업이 자동으로 순차 진행됩니다..."
+            echo ""
+            
+            # 전체 초기화 스크립트 실행
+            cd ../conf/docker/conf/mc-iam-manager/ || {
+                echo "오류: mc-iam-manager 디렉토리를 찾을 수 없습니다."
+                cd "$ORIGINAL_DIR"
+                exit 1
+            }
+            
+            if [ -f "1_setup_auto.sh" ]; then
+                chmod +x 1_setup_auto.sh
+                ./1_setup_auto.sh
+                if [ $? -eq 0 ]; then
+                    echo ""
+                    echo "✓ 전체 초기화가 완료되었습니다."
+                    echo "MC-IAM-Manager가 정상적으로 설정되었습니다."
+                else
+                    echo ""
+                    echo "❌ 전체 초기화 중 오류가 발생했습니다."
+                    cd "$ORIGINAL_DIR"
+                    exit 1
+                fi
+            else
+                echo "오류: 1_setup_auto.sh 파일을 찾을 수 없습니다."
+                cd "$ORIGINAL_DIR"
+                exit 1
+            fi
+            
+            break
+            ;;
+        2)
+            echo ""
+            echo "부분 초기화-수동 모드를 선택하셨습니다."
+            echo "초기화 가능한 작업 목록에서 원하는 항목을 선택하세요..."
+            echo ""
+            
+            # 부분 초기화 스크립트 실행
+            cd ../conf/docker/conf/mc-iam-manager/ || {
+                echo "오류: mc-iam-manager 디렉토리를 찾을 수 없습니다."
+                cd "$ORIGINAL_DIR"
+                exit 1
+            }
+            
+            if [ -f "1_setup_manual.sh" ]; then
+                chmod +x 1_setup_manual.sh
+                ./1_setup_manual.sh
+                if [ $? -eq 0 ]; then
+                    echo ""
+                    echo "✓ 부분 초기화가 완료되었습니다."
+                    echo "선택한 초기화 작업이 정상적으로 수행되었습니다."
+                else
+                    echo ""
+                    echo "❌ 부분 초기화 중 오류가 발생했습니다."
+                    cd "$ORIGINAL_DIR"
+                    exit 1
+                fi
+            else
+                echo "오류: 1_setup_manual.sh 파일을 찾을 수 없습니다."
+                cd "$ORIGINAL_DIR"
+                exit 1
+            fi
+            
+            break
+            ;;
+        *)
+            echo "잘못된 선택입니다. 1 또는 2를 입력해주세요."
+            ;;
+    esac
+done
+
+# 모든 초기화 작업 완료 후 원래 위치로 돌아가기
+cd "$ORIGINAL_DIR"
+
+echo ""
+echo "======================================================"
+echo "초기화 작업이 완료되었습니다!"
+echo "MC-IAM-Manager가 정상적으로 설정되었습니다."
+echo "======================================================"
+

--- a/bin/cleanAll
+++ b/bin/cleanAll
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# 경고 메시지 및 사용자 확인
+cat <<EOF
+[WARNING]
+This shell script will delete ALL Docker images, containers, volumes, networks, and also remove all container-volume directories used for persistent data.
+This is intended to reset your environment to a clean state.
+Are you sure you want to continue? (y/n)
+EOF
+read -r answer
+if [[ ! "$answer" =~ ^[Yy]$ ]]; then
+  echo "Aborted by user."
+  exit 1
+fi
+
+# 모든 Docker 이미지 삭제
+echo "All Docker images deleting..."
+if [ -n "$(docker images -q)" ]; then
+  echo "docker rmi \$(docker images -q) -f"
+  docker rmi $(docker images -q) -f
+else
+  echo "The docker image to delete does not exist."
+  echo "All docker images have already been deleted."
+fi
+
+echo
+# 모든 컨테이너 중지 및 삭제
+echo "Stopping and deleting all Docker containers..."
+if [ -n "$(docker ps -aq)" ]; then
+  echo "docker stop \$(docker ps -aq)"
+  docker stop $(docker ps -aq)
+  echo "docker rm \$(docker ps -aq)"
+  docker rm $(docker ps -aq)
+else
+  echo "No containers to stop or delete."
+fi
+
+echo
+# 모든 사용되지 않는 Docker 시스템 리소스 정리
+echo "docker system prune -a -f"
+docker system prune -a -f
+
+echo
+# 모든 볼륨 삭제
+echo "Deleting all Docker volumes..."
+if [ -n "$(docker volume ls -q)" ]; then
+  echo "docker volume rm \$(docker volume ls -q)"
+  docker volume rm $(docker volume ls -q)
+else
+  echo "No volumes to delete."
+fi
+
+echo
+# 모든 네트워크 삭제
+echo "docker network prune -f"
+docker network prune -f
+
+echo
+# container-volume 폴더 삭제 (호스트 마운트 포인트)
+echo "Deleting container-volume directories..."
+if [ -d "../conf/docker/container-volume" ]; then
+  echo "sudo rm -rf ../conf/docker/container-volume"
+  sudo rm -rf ../conf/docker/container-volume
+  echo "container-volume directories deleted successfully."
+else
+  echo "container-volume directory does not exist."
+fi
+
+echo
+# Docker 시스템 리소스 정보 표시
+echo "docker system df"
+docker system df

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -701,7 +701,7 @@ services:
 
   mc-web-console-api:
     # image: sehyeong0108/mc-web-console-api:20241101
-    image: cloudbaristaorg/mc-web-console-api:0.4.0
+    image: cloudbaristaorg/mc-web-console-api:0.4.1
     container_name: mc-web-console-api
     restart: on-failure
     depends_on:
@@ -739,7 +739,7 @@ services:
 
   mc-web-console-front:
     # image: sehyeong0108/mc-web-console-front:20241101
-    image: cloudbaristaorg/mc-web-console-front:0.4.0
+    image: cloudbaristaorg/mc-web-console-front:0.4.1
     container_name: mc-web-console-front
     depends_on:
       - mc-web-console-api


### PR DESCRIPTION
Add initialization and configuration scripts for MC-IAM-Manager

- Introduced `1iam_manager_set_mode.sh` for selecting between development and production modes, including setup for self-signed and Let's Encrypt certificates.
- Added `2iam_manager_init.sh` for initializing the MC-IAM-Manager with options for full and partial initialization.
- Created `cleanAll` script to reset the Docker environment by removing all images, containers, volumes, and networks.
- Updated `docker-compose.yaml` to use version 0.4.1 for `mc-web-console-api` and `mc-web-console-front` services.