### PR TITLE
Update Docker images for mc-infra-connector and mc-infra-manager

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
 ##### MC-INFRA-CONNECTOR #########################################################################################################################
 
   mc-infra-connector:
-    image: cloudbaristaorg/cb-spider:0.11.1
+    image: cloudbaristaorg/cb-spider:0.11.4
     pull_policy: missing
     container_name: mc-infra-connector
     platform: linux/amd64
@@ -51,7 +51,7 @@ services:
 ##### MC-INFRA-MANAGER #########################################################################################################################
 
   mc-infra-manager:
-    image: cloudbaristaorg/cb-tumblebug:0.11.1
+    image: cloudbaristaorg/cb-tumblebug:0.11.8
     container_name: mc-infra-manager
     pull_policy: missing
     platform: linux/amd64


### PR DESCRIPTION
CB-Tumblebug From 0.11.1 to 0.11.8

-  migration guide: https://github.com/cloud-barista/cb-tumblebug/blob/main/docs/migration_guide_0.11.1_to_0.11.8.md