### PR TITLE
Upgrade cb-tumblebug, cb-spider, mc-iam-manager, mc-web-console versions

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -3,7 +3,7 @@
 
 services:
   mc-infra-connector:
-    version: 0.11.1
+    version: 0.12.14
     baseurl: http://mc-infra-connector:1024/spider
     auth:
       type: basic
@@ -11,13 +11,13 @@ services:
       password:
 
   mc-iam-manager:
-    version: 0.4.5
+    version: 0.5.1
     baseurl: http://mc-iam-manager:5000
     auth:
       type: bearer
 
   mc-infra-manager:
-    version: 0.11.1
+    version: 0.12.6
     baseurl: http://mc-infra-manager:1323/tumblebug
     auth:
       type: basic
@@ -25,7 +25,7 @@ services:
       password: default
 
   mc-web-console:
-    version: 0.4.5
+    version: 0.5.2
     baseurl: http://mc-web-console:3000
     auth:
       type: bearer

--- a/conf/docker/conf/mc-web-console/api/conf/api.yaml
+++ b/conf/docker/conf/mc-web-console/api/conf/api.yaml
@@ -3,7 +3,7 @@
 
 services:
   mc-infra-connector:
-    version: 0.11.1
+    version: 0.12.14
     baseurl: http://mc-infra-connector:1024/spider
     auth:
       type: basic
@@ -11,13 +11,13 @@ services:
       password:
 
   mc-iam-manager:
-    version: 0.4.5
+    version: 0.5.1
     baseurl: http://mc-iam-manager:5000
     auth:
       type: bearer
 
   mc-infra-manager:
-    version: 0.11.1
+    version: 0.12.6
     baseurl: http://mc-infra-manager:1323/tumblebug
     auth:
       type: basic
@@ -25,7 +25,7 @@ services:
       password: default
 
   mc-web-console:
-    version: 0.4.5
+    version: 0.5.2
     baseurl: http://mc-web-console:3000
     auth:
       type: bearer

--- a/conf/docker/docker-compose.mini.yaml
+++ b/conf/docker/docker-compose.mini.yaml
@@ -14,7 +14,7 @@ services:
   ##### MC-INFRA-CONNECTOR #########################################################################################################################
 
   mc-infra-connector:
-    image: cloudbaristaorg/cb-spider:0.11.1
+    image: cloudbaristaorg/cb-spider:0.12.14
     pull_policy: missing
     container_name: mc-infra-connector
     platform: linux/amd64
@@ -47,7 +47,7 @@ services:
   ##### MC-INFRA-MANAGER #########################################################################################################################
 
   mc-infra-manager:
-    image: cloudbaristaorg/cb-tumblebug:0.11.1
+    image: cloudbaristaorg/cb-tumblebug:0.12.6
     container_name: mc-infra-manager
     pull_policy: missing
     platform: linux/amd64
@@ -180,7 +180,7 @@ services:
 
   mc-iam-manager:
     container_name: mc-iam-manager
-    image: cloudbaristaorg/mc-iam-manager:edge
+    image: cloudbaristaorg/mc-iam-manager:0.5.1
     pull_policy: missing
     platform: linux/amd64
     restart: unless-stopped
@@ -339,7 +339,7 @@ services:
 
   mc-web-console-api:
     # image: sehyeong0108/mc-web-console-api:20241101
-    image: cloudbaristaorg/mc-web-console-api:0.4.1
+    image: cloudbaristaorg/mc-web-console-api:0.5.2
     container_name: mc-web-console-api
     platform: linux/amd64
     restart: unless-stopped
@@ -379,7 +379,7 @@ services:
 
   mc-web-console-front:
     # image: sehyeong0108/mc-web-console-front:20241101
-    image: cloudbaristaorg/mc-web-console-front:0.4.1
+    image: cloudbaristaorg/mc-web-console-front:0.5.2
     container_name: mc-web-console-front
     platform: linux/amd64
     restart: unless-stopped

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
 ##### MC-INFRA-CONNECTOR #########################################################################################################################
 
   mc-infra-connector:
-    image: cloudbaristaorg/cb-spider:0.12.0
+    image: cloudbaristaorg/cb-spider:0.12.14
     pull_policy: missing
     container_name: mc-infra-connector
     platform: linux/amd64
@@ -56,7 +56,7 @@ services:
 ##### MC-INFRA-MANAGER #########################################################################################################################
 
   mc-infra-manager:
-    image: cloudbaristaorg/cb-tumblebug:0.12.1
+    image: cloudbaristaorg/cb-tumblebug:0.12.6
     container_name: mc-infra-manager
     pull_policy: missing
     platform: linux/amd64
@@ -194,7 +194,7 @@ services:
     container_name: mc-iam-manager
     # image: mc-iam-manager:latest
     #image: cloudbaristaorg/mc-iam-manager:edge
-    image: cloudbaristaorg/mc-iam-manager:0.5.0
+    image: cloudbaristaorg/mc-iam-manager:0.5.1
     restart: unless-stopped
     networks:
       - mc-iam-manager-network
@@ -915,7 +915,7 @@ services:
             exec docker-entrypoint.sh postgres"
 
   mc-web-console-api:
-    image: cloudbaristaorg/mc-web-console-api:0.5.1
+    image: cloudbaristaorg/mc-web-console-api:0.5.2
     #image: cloudbaristaorg/mc-web-console-api:edge
     container_name: mc-web-console-api
     platform: linux/amd64
@@ -955,7 +955,7 @@ services:
       <<: *default-health-check
 
   mc-web-console-front:
-    image: cloudbaristaorg/mc-web-console-front:0.5.1
+    image: cloudbaristaorg/mc-web-console-front:0.5.2
     #image: cloudbaristaorg/mc-web-console-front:edge
     container_name: mc-web-console-front
     platform: linux/amd64


### PR DESCRIPTION
- cb-spider: 0.12.0 → 0.12.14 (required by cb-tumblebug v0.12.6)
- cb-tumblebug: 0.12.1 → 0.12.6 (breaking changes, clean install required)
- mc-iam-manager: 0.5.0 → 0.5.1
- mc-web-console-api/front: 0.5.1 → 0.5.2
- mini compose: align all versions to match production