### PR TITLE
fix(docker): add restart policy to mc-infra-manager and dependencies

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
     image: cloudbaristaorg/cb-spider:0.12.18
     pull_policy: missing
     container_name: mc-infra-connector
+    restart: unless-stopped
     platform: linux/amd64
     networks:
       - mc-infra-connector-network
@@ -58,6 +59,7 @@ services:
   mc-infra-manager:
     image: cloudbaristaorg/cb-tumblebug:0.12.9
     container_name: mc-infra-manager
+    restart: unless-stopped
     pull_policy: missing
     platform: linux/amd64
     networks:
@@ -125,6 +127,7 @@ services:
   mc-infra-manager-etcd:
     image: gcr.io/etcd-development/etcd:v3.5.21
     container_name: mc-infra-manager-etcd
+    restart: unless-stopped
     networks:
       - mc-infra-manager-network
     ports:


### PR DESCRIPTION
## Summary
- `mc-infra-connector`, `mc-infra-manager-etcd`, `mc-infra-manager`에 `restart: unless-stopped` 추가
- 서버 재부팅 후 `mc-infra-manager-postgres`(DB)만 자동 기동되던 문제 수정
- 이제 mc-infra-manager 전체 스택이 호스트 재부팅 시 함께 자동으로 기동됨
