### PR TITLE
fix(iam-env): sync .env.setup files and replace real domain with placeholder

### DIFF
--- a/conf/docker/.env.setup
+++ b/conf/docker/.env.setup
@@ -158,7 +158,7 @@ CSP_ROLE_PREFIX=mciam
 # Mode A (도메인 없음): 로컬 자가서명 인증서 사용. 0_preset_dev.sh 로 인증서 생성 후 사용.
 MC_IAM_MANAGER_PUBLIC_DOMAIN=mciam.local
 # Mode B (운영 / 외부 도메인): 아래 주석 해제 후 FQDN 설정. 0_preset_prod.sh + Let's Encrypt 필요.
-# MC_IAM_MANAGER_PUBLIC_DOMAIN=mciam.onecloudcon.com
+# MC_IAM_MANAGER_PUBLIC_DOMAIN=<real domain>
 MC_IAM_MANAGER_PUBLIC_HOST=https://${MC_IAM_MANAGER_PUBLIC_DOMAIN}
 MC_IAM_MANAGER_PUBLIC_KEYCLOAK_HOST=${MC_IAM_MANAGER_PUBLIC_HOST}/auth
 

--- a/conf/docker/conf/mc-iam-manager/.env.setup
+++ b/conf/docker/conf/mc-iam-manager/.env.setup
@@ -49,7 +49,7 @@ MC_IAM_MANAGER_DATABASE_URL=postgres://mciamdbadmin:mciamdbpassword@mc-iam-manag
 MC_IAM_MANAGER_KEYCLOAK_DOMAIN=mc-iam-manager-kc
 MC_IAM_MANAGER_KEYCLOAK_PORT=8080
 MC_IAM_MANAGER_KEYCLOAK_HOST=http://mc-iam-manager-kc:8080/auth
-MC_IAM_MANAGER_KEYCLOAK_DATABASE_NAME=mc_iam_keycloak_db
+MC_IAM_MANAGER_KEYCLOAK_DB_DATABASE_NAME=mc_iam_keycloak_db
 MC_IAM_MANAGER_KEYCLOAK_REALM=mciam
 MC_IAM_MANAGER_KEYCLOAK_CLIENT_PATH=mc-iam-manager-kc/realms/mciam
 MC_IAM_MANAGER_KEYCLOAK_ADMIN=admin
@@ -59,6 +59,12 @@ MC_IAM_MANAGER_KEYCLOAK_ADMIN_PASSWORD=admin_password
 MCINFRAMANAGER=http://mc-infra-manager:1323/tumblebug
 MCINFRAMANAGER_APIUSERNAME=default
 MCINFRAMANAGER_APIPASSWORD=default
+MC_INFRA_MANAGER_API_USERNAME=default
+MC_INFRA_MANAGER_API_PASSWORD=default
+
+## mc-infra-connector
+MC_INFRA_CONNECTOR_API_USERNAME=default
+MC_INFRA_CONNECTOR_API_PASSWORD=default
 
 DEFAULT_WORKSPACE_NAME=ws01
 
@@ -69,3 +75,11 @@ IDENTITY_PROVIDER_ARN_AWS=arn:aws:iam::notyet:oidc-provider/mc-iam-manager-kc/re
 IDENTITY_ROLE_ARN_AWS=arn:aws:iam::mc-iam-manager-kc:role/mciam-platformadmin
 
 CSP_ROLE_PREFIX=mciam
+
+# === 외부 노출 도메인 (브라우저 ↔ nginx HTTPS) ===
+# Mode A (도메인 없음): 로컬 자가서명 인증서. 0_preset_dev.sh 로 생성.
+MC_IAM_MANAGER_PUBLIC_DOMAIN=mciam.local
+# Mode B (운영): 아래 주석 해제 후 FQDN 설정. 0_preset_prod.sh + Let's Encrypt 필요.
+# MC_IAM_MANAGER_PUBLIC_DOMAIN=<real domain>
+MC_IAM_MANAGER_PUBLIC_HOST=https://${MC_IAM_MANAGER_PUBLIC_DOMAIN}
+MC_IAM_MANAGER_PUBLIC_KEYCLOAK_HOST=${MC_IAM_MANAGER_PUBLIC_HOST}/auth


### PR DESCRIPTION
## Summary

- `conf/docker/conf/mc-iam-manager/.env.setup`에 누락된 변수 8개 추가 및 키 이름 정합
  - `MC_INFRA_MANAGER_API_USERNAME/PASSWORD`, `MC_INFRA_CONNECTOR_API_USERNAME/PASSWORD` 추가
  - `MC_IAM_MANAGER_PUBLIC_DOMAIN/HOST/KEYCLOAK_HOST` 섹션 신설 (Mode A 기본값: `mciam.local`)
  - `MC_IAM_MANAGER_KEYCLOAK_DATABASE_NAME` → `MC_IAM_MANAGER_KEYCLOAK_DB_DATABASE_NAME` 리네임
- 두 `.env.setup` 파일의 Mode B 예시 도메인을 실제 도메인(`mciam.onecloudcon.com`)에서 `<real domain>` 플레이스홀더로 교체
- `.env`는 gitignore 대상이므로 `.env.setup`이 단일 진실원(source of truth)이어야 하는데, 기존에는 `.env.setup`만으로 시작 시 `MC_IAM_MANAGER_PUBLIC_DOMAIN` 등이 누락되어 `0_preset_prod.sh` nginx 템플릿 치환이 깨지는 문제가 있었음

## Test plan

- [ ] `cp conf/docker/conf/mc-iam-manager/.env.setup conf/docker/conf/mc-iam-manager/.env` 후 변수 키 diff 없음 확인
- [ ] Mode A (`mciam.local`) 기준 `0_preset_dev.sh` 실행 → nginx.conf 정상 생성 및 자가서명 인증서 발급 확인
- [ ] `mcc infra run -s mc-iam-manager` → nginx/DB/Keycloak 컨테이너 정상 기동 확인