### PR TITLE
fix(iam): mc-iam-manager startup ordering, post-init recovery, and sudo-free preset-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,33 @@ The following ports must be registered in the firewall:
 
 ---
 
+# Troubleshooting
+
+## `mc-iam-manager` Stays Unhealthy After Install
+
+If `./mcc infra info` shows `mc-iam-manager` as **unhealthy** and
+`docker logs mc-iam-manager-post-initial` ends with `ERROR: 1_setup_auto.sh Script execution failed`,
+the post-init container started before `mc-iam-manager` finished its first boot.
+
+**Recovery steps:**
+
+```bash
+# 1. Confirm all prerequisites are healthy
+cd bin && ./mcc infra info
+
+# 2. Remove the exited post-init container, then re-run it (idempotent — safe to repeat)
+docker rm mc-iam-manager-post-initial 2>/dev/null
+./mcc infra run -s mc-iam-manager-post-initial
+docker logs -f mc-iam-manager-post-initial
+# Each of the 8 setup steps should finish with ✓
+
+# 3. Verify
+curl -s http://localhost:5000/readyz | jq .
+# Expected: "status": "healthy"
+```
+
+---
+
 # Build from Source
 
 ## Build a Static Binary

--- a/README_kr.md
+++ b/README_kr.md
@@ -284,6 +284,33 @@ cd mc-admin-cli/bin
 
 ---
 
+# 트러블슈팅
+
+## 설치 후 `mc-iam-manager`가 계속 unhealthy 상태일 때
+
+`./mcc infra info`에서 `mc-iam-manager`가 **unhealthy**로 표시되고,
+`docker logs mc-iam-manager-post-initial`의 마지막 줄이 `ERROR: 1_setup_auto.sh Script execution failed`라면,
+`mc-iam-manager`가 완전히 기동되기 전에 post-init 컨테이너가 먼저 실행된 것입니다.
+
+**복구 절차:**
+
+```bash
+# 1. 모든 사전 조건 컨테이너가 healthy인지 확인
+cd bin && ./mcc infra info
+
+# 2. 종료된 post-init 컨테이너를 제거한 뒤 재실행 (멱등성 보장 — 반복 실행 안전)
+docker rm mc-iam-manager-post-initial 2>/dev/null
+./mcc infra run -s mc-iam-manager-post-initial
+docker logs -f mc-iam-manager-post-initial
+# 8단계 각각이 ✓ 로 완료되어야 합니다
+
+# 3. 헬스 상태 확인
+curl -s http://localhost:5000/readyz | jq .
+# 기대 결과: "status": "healthy"
+```
+
+---
+
 # 소스에서 빌드
 
 ## 정적 바이너리 빌드

--- a/conf/docker/conf/mc-iam-manager/.env.setup
+++ b/conf/docker/conf/mc-iam-manager/.env.setup
@@ -3,6 +3,7 @@
 ## .env.setup 기반으로 생성 - 운영 환경에서는 비밀번호 등을 반드시 변경하세요
 
 # 기본 서비스 설정
+# MC_IAM_MANAGER_DOMAIN: Docker 내부 컨테이너 이름 — 공개 도메인(PUBLIC_DOMAIN)과 다름, 변경 금지
 MC_IAM_MANAGER_DOMAIN=mc-iam-manager
 MC_IAM_MANAGER_PORT=5000
 MC_IAM_MANAGER_HOST=http://mc-iam-manager:5000

--- a/conf/docker/conf/mc-iam-manager/0_preset_dev.sh
+++ b/conf/docker/conf/mc-iam-manager/0_preset_dev.sh
@@ -28,9 +28,27 @@ CURRENT_GROUP=$(id -gn)
 
 echo "Current user: ${CURRENT_USER}:${CURRENT_GROUP}"
 
-mkdir -p "${CERT_PARENT_DIR}" || { echo "Error: Failed to create ${CERT_PARENT_DIR}"; exit 1; }
-chown -R "${CURRENT_USER}:${CURRENT_GROUP}" "${CERT_PARENT_DIR}" || { echo "Error: Failed to change ownership of ${CERT_PARENT_DIR}"; exit 1; }
-echo "✓ Container volume directory created and permissions set"
+# Only the certs/ and nginx/ subdirs need to be writable by this script.
+# postgres/ and keycloak/ are Docker-managed and may be root-owned from a
+# previous run — do not touch them. Newly mkdir'd dirs are user-owned automatically,
+# so chown is unnecessary. If mkdir or the writable check fails, the root-owned
+# state must be cleared first via cleanAll.sh (which handles sudo interactively).
+for _dir in "${CERT_PARENT_DIR}/certs" "${CERT_PARENT_DIR}/nginx"; do
+    if ! mkdir -p "$_dir" 2>/dev/null; then
+        echo "❌ Error: Cannot create $_dir"
+        echo "   A previous Docker run likely left root-owned files in the parent directory."
+        echo "   Please run the cleanup script first, then re-run installAll.sh:"
+        echo "       cd ${SCRIPT_DIR}/../../bin && ./cleanAll.sh"
+        exit 1
+    fi
+    if [ ! -w "$_dir" ]; then
+        echo "❌ Error: $_dir exists but is not writable by ${CURRENT_USER}."
+        echo "   Please run the cleanup script first, then re-run installAll.sh:"
+        echo "       cd ${SCRIPT_DIR}/../../bin && ./cleanAll.sh"
+        exit 1
+    fi
+done
+echo "✓ Certificate and nginx directories ready"
 
 
 # 템플릿 파일 경로

--- a/conf/docker/conf/mc-iam-manager/docker-post-init.sh
+++ b/conf/docker/conf/mc-iam-manager/docker-post-init.sh
@@ -85,7 +85,32 @@ if [ -f '1_setup_auto.sh' ]; then
   if bash 1_setup_auto.sh; then
     echo 'Script executed successfully with bash 1_setup_auto.sh'
   else
-    echo 'ERROR: 1_setup_auto.sh Script execution failed'
+    cat <<'RECOVERY'
+====================================================================
+ERROR: 1_setup_auto.sh failed.
+
+mc-iam-manager was likely not yet ready when setup ran.
+To recover manually:
+
+1. Wait ~2 minutes for all containers to stabilize.
+
+2. From the bin/ directory, check service status:
+       ./mcc infra info
+
+   Confirm mc-iam-manager and mc-infra-manager are both running.
+
+3. Re-run the post-init container (idempotent — safe to repeat):
+       docker rm mc-iam-manager-post-initial 2>/dev/null
+       cd <repo>/bin && ./mcc infra run -s mc-iam-manager-post-initial
+       docker logs -f mc-iam-manager-post-initial
+
+   Each of the 8 setup steps should finish with ✓.
+
+4. Verify health:
+       curl -s http://localhost:5000/readyz | jq .
+   Expected: "status": "healthy"
+====================================================================
+RECOVERY
     exit 1
   fi
 else

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -244,9 +244,14 @@ services:
         published: ${MC_IAM_MANAGER_PORT}
         protocol: tcp
     depends_on:
-      - mc-iam-manager-db
-      - mc-iam-manager-kc
-      - mc-iam-manager-nginx
+      mc-iam-manager-db:
+        condition: service_healthy
+      mc-iam-manager-kc:
+        condition: service_healthy
+      mc-iam-manager-nginx:
+        condition: service_started
+      mc-infra-manager:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgres://${MC_IAM_MANAGER_DATABASE_USER}:${MC_IAM_MANAGER_DATABASE_PASSWORD}@${MC_IAM_MANAGER_DATABASE_HOST}:5432/${MC_IAM_MANAGER_DATABASE_NAME}
       PORT: ${MC_IAM_MANAGER_PORT}


### PR DESCRIPTION
## Summary

- `docker-compose.yaml`: `mc-iam-manager.depends_on`에 `mc-infra-manager: condition: service_healthy` 추가 — cold start 시 mc-infra-manager DNS resolve 실패 수정; db/kc도 `service_healthy`로 강화
- `0_preset_dev.sh`: `chown -R` 전체 트리 대신 `certs/`, `nginx/` 두 서브디렉토리만 targeted `mkdir` + writable check; sudo 의존 완전 제거, 실패 시 `cleanAll.sh` 안내
- `docker-post-init.sh`: `1_setup_auto.sh` 실패 시 `mcc infra run` 기반 복구 가이드 출력
- `README.md` / `README_kr.md`: Step 1-1 GLIBC 오류 조기 노출, 정적 바이너리 빌드 섹션, 트러블슈팅 섹션(mc-iam-manager unhealthy 수동 복구) 추가
- `.env.setup`: `MC_IAM_MANAGER_DOMAIN`이 Docker 내부 컨테이너 이름임을 명시하는 주석 추가 (공개 도메인과 혼용 방지)

## Root Cause (두 갈래)

1. `mc-iam-manager.depends_on`에 `mc-infra-manager` 부재 → cold start 시 Docker embedded DNS 등록 전에 health check 실행 → `mc-infra-manager` 컴포넌트 영구 unhealthy
2. `docker-post-init.sh`의 `sleep 60`이 충분하지 않으면 `mc-iam-manager` API가 준비되기 전에 `1_setup_auto.sh` 실행 → HTTP 000 → 전체 setup 중단

## Test

로컬 테스트 완료:
- `mc-iam-manager` (healthy) ✓ — 모든 컴포넌트(keycloak, db, nginx, mc-infra-manager) 통과
- post-initial 8단계(admin 초기화 → 역할 → 메뉴 → API → 프레임워크 서비스 → 프로젝트 동기화 → KC redirect URI → 워크스페이스 매핑) 모두 ✓, Exit 0
- `/readyz` → `"status": "healthy"` ✓
- admin 로그인 → access_token 발급 ✓

## Test Plan

- [ ] `bin/cleanAll.sh` 후 `bin/installAll.sh -m dev -d mciam.local -r background`
- [ ] `mc-iam-manager`가 `mc-infra-manager` healthy 대기 후 시작하는지 확인
- [ ] `docker logs -f mc-iam-manager-post-initial` — 8단계 ✓ 완료
- [ ] `curl -s http://localhost:5000/readyz | jq .` → `"status": "healthy"`