### PR TITLE
fix(web-console): remove optional deps and sync api.yaml mc-iam-manager entries

### DIFF
--- a/conf/docker/conf/mc-web-console/api/conf/api.yaml
+++ b/conf/docker/conf/mc-web-console/api/conf/api.yaml
@@ -669,6 +669,10 @@ serviceActions:
       method: post
       resourcePath: /api/mcmp-apis/list
       description: "전체 프레임워크 서비스 목록 및 BaseURL 조회."
+    CreateFrameworkService:
+      method: post
+      resourcePath: /api/mcmp-apis
+      description: "프레임워크 서비스 신규 등록. body: {name, version, baseUrl, authType, isActive}"
     UpdateFrameworkService:
       method: put
       resourcePath: /api/mcmp-apis/name/{serviceName}
@@ -978,7 +982,7 @@ serviceActions:
       description: "특정 사용자의 워크스페이스 목록조회"
     Createuser:
       method: post
-      resourcePath: /api/user
+      resourcePath: /api/users
       description: "유저를 등록합니다."
     Deactiveuser:
       method: post
@@ -992,6 +996,186 @@ serviceActions:
       method: post
       resourcePath: /api/roles/assign/platform-role
       description: "Platform Role 할당"
+    Signup:
+      method: post
+      resourcePath: /api/auth/signup
+      description: "신규 사용자 회원가입 (관리자 승인 후 로그인 가능)"
+    GetCspRoleById:
+      method: get
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: "CSP Role 단건 조회"
+    CreateCspRole:
+      method: post
+      resourcePath: /api/roles/csp
+      description: "CSP Role 생성"
+    DeleteCspRole:
+      method: delete
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: "CSP Role 삭제"
+    listCspPolicies:
+      method: post
+      resourcePath: /api/csp-policies/list
+      description: "CSP Policy 목록 조회"
+    GetCspPolicyById:
+      method: get
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 단건 조회"
+    CreateCspPolicy:
+      method: post
+      resourcePath: /api/csp-policies
+      description: "CSP Policy 생성"
+    UpdateCspPolicy:
+      method: put
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 수정"
+    DeleteCspPolicy:
+      method: delete
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 삭제"
+    GetPoliciesByRoleId:
+      method: get
+      resourcePath: /api/csp-policies/role/{roleId}
+      description: "CSP Role에 연결된 Policy 목록 조회"
+    AttachPolicyToRole:
+      method: post
+      resourcePath: /api/csp-policies/attach
+      description: "CSP Policy를 Role에 연결"
+    DetachPolicyFromRole:
+      method: post
+      resourcePath: /api/csp-policies/detach
+      description: "CSP Policy를 Role에서 해제"
+    SyncCspPolicies:
+      method: post
+      resourcePath: /api/csp-policies/sync
+      description: "CSP Policy 동기화"
+    Listmenustree:
+      method: post
+      resourcePath: /api/menus/menus-tree/list
+      description: "List all menus as tree structure (Admin only)"
+    Createmenu:
+      method: post
+      resourcePath: /api/menus
+      description: "Create a new menu"
+    Getmenubyid:
+      method: get
+      resourcePath: /api/menus/id/{menuId}
+      description: "Get menu details by ID"
+    Updatemenu:
+      method: put
+      resourcePath: /api/menus/id/{menuId}
+      description: "Update menu details"
+    Deletemenu:
+      method: delete
+      resourcePath: /api/menus/id/{menuId}
+      description: "Delete a menu"
+    UpdateUserStatus:
+      method: post
+      resourcePath: /api/users/id/{userId}/status
+      description: "사용자 승인/비활성화 (enabled true/false)"
+    ResetUserPassword:
+      method: put
+      resourcePath: /api/users/id/{userId}/password
+      description: "관리자가 사용자 비밀번호 재설정"
+    ChangeMyPassword:
+      method: put
+      resourcePath: /api/users/me/password
+      description: "사용자 본인 비밀번호 변경"
+    Createorganization:
+      method: post
+      resourcePath: /api/organizations
+      description: "그룹 생성"
+    Getorganizations:
+      method: get
+      resourcePath: /api/organizations
+      description: "그룹 목록/트리 조회 (query: tree=true면 중첩 구조)"
+    Getorganizationbyid:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 단건 조회 by ID"
+    Getorganizationbycode:
+      method: get
+      resourcePath: /api/organizations/code/{code}
+      description: "그룹 단건 조회 by code"
+    Updateorganization:
+      method: put
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 수정 (부모 변경 시 하위 코드 자동 재생성)"
+    Deleteorganization:
+      method: delete
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 삭제 (하위 그룹·소속 사용자 있으면 400)"
+    Getorganizationusers:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}/users
+      description: "그룹 소속 사용자 목록"
+    Assignuserorganizations:
+      method: post
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 그룹 할당 (다중)"
+    Getuserorganizations:
+      method: get
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 소속 그룹 목록"
+    Removeuserorganization:
+      method: delete
+      resourcePath: /api/users/id/{userId}/organizations/{organizationId}
+      description: "사용자 그룹 제거"
+    listCspAccounts:
+      method: post
+      resourcePath: /api/csp-accounts/list
+      description: "CSP 계정 목록 조회 (필터: csp_type)"
+    createCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts
+      description: "CSP 계정 등록"
+    getCspAccountByID:
+      method: get
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 단건 조회 by ID"
+    updateCspAccount:
+      method: put
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 수정"
+    deleteCspAccount:
+      method: delete
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 삭제"
+    validateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/validate
+      description: "CSP 계정 자격증명 유효성 검증"
+    activateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/activate
+      description: "CSP 계정 활성화"
+    deactivateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/deactivate
+      description: "CSP 계정 비활성화"
+    GetProjectSyncDiff:
+      method: get
+      resourcePath: /api/setup/projects/sync-diff
+      description: "Infra NS ↔ IAM Project 동기화 차이 조회"
+    ApplyProjectSync:
+      method: post
+      resourcePath: /api/setup/projects/sync
+      description: "nsIds + workspaceId를 받아 Project 생성 + Workspace 할당"
+    listMenus:
+      method: post
+      resourcePath: /api/menus/list
+      description: "메뉴 목록 조회 (전체)"
+    InitialMenus:
+      method: post
+      resourcePath: /api/setup/initial-menus
+      description: "menu.yaml 기반 메뉴 일괄 재등록 (1_setup_auto.sh init_menu와 동일)"
+    SyncMcmpApis:
+      method: post
+      resourcePath: /api/setup/sync-mcmp-apis
+      description: "api.yaml 기반 mcmpApi 카탈로그 재동기화 (1_setup_auto.sh init_api_resources와 동일)"
+    syncProjects:
+      method: post
+      resourcePath: /api/setup/sync-projects
+      description: "mc-infra-manager의 namespace 목록을 가져와 project 테이블과 동기화"
 
   mc-infra-manager:
     GetCredentialHolderList:

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -996,11 +996,6 @@ services:
       - mc-infra-connector
       - mc-infra-manager
       - mc-iam-manager
-      - mc-observability-manager
-      - mc-workflow-manager
-      - mc-data-manager
-      - mc-application-manager
-      - mc-cost-optimizer-be
     ports:
       - target: 3000
         published: ${MC_WEB_CONSOLE_API_PORT}
@@ -1023,8 +1018,6 @@ services:
       IFRAME_TARGET_IS_HOST: true
       MC_IAM_MANAGER_HOST: mc-iam-manager
       MC_IAM_MANAGER_PORT: ${MC_IAM_MANAGER_PORT}
-      MC_OBSERVABILITY_GRAFANA_PUBLIC_HOST: ${MC_OBSERVABILITY_GRAFANA_PUBLIC_HOST}
-      MC_COST_OPTIMIZER_FE_PUBLIC_HOST: ${MC_COST_OPTIMIZER_FE_PUBLIC_HOST}
     volumes:
       - ./tool/mcc:/app/tool/mcc
       - ./conf/mc-web-console/api/conf/:/conf/


### PR DESCRIPTION
## Summary

- `mc-web-console-api.depends_on`에서 선택적 서비스 5개 및 관련 환경변수 2개 제거
- 런타임 `api.yaml`의 mc-iam-manager operationId 누락 항목 46개 추가 및 경로 오류 수정

---

## PR #22: fix(web-console): remove optional service deps from mc-web-console-api

### 문제

`mcc infra run -s mc-web-console-front` 실행 시 아래 오류로 기동 실패:

```
dependency failed to start: container mc-observability-grafana is unhealthy
```

의존성 체인: `mc-web-console-front → mc-web-console-api → mc-observability-manager → mc-observability-grafana (condition: service_healthy)`

### 변경

`mc-web-console-api.depends_on`에서 선택적 서비스 5개 제거:
- `mc-observability-manager`, `mc-workflow-manager`, `mc-data-manager`, `mc-application-manager`, `mc-cost-optimizer-be`

`environment`에서 관련 변수 2개 제거:
- `MC_OBSERVABILITY_GRAFANA_PUBLIC_HOST`, `MC_COST_OPTIMIZER_FE_PUBLIC_HOST`

이 서비스들은 런타임에 iframe/HTTP 호출로 통합되는 선택적 기능이므로 부재 시 해당 메뉴만 degraded, 콘솔 기동에는 영향 없음.

---

## PR #23: fix(web-console): sync mc-iam-manager entries in runtime api.yaml

### 문제

`mc-web-console-api` proxy가 `conf/api.yaml`에 없는 operationId 요청 시 404 반환.

`CreateFrameworkService` 등 mc-web-console 소스의 `conf/api.yaml`에는 있지만 mc-admin-cli 런타임 `api.yaml`에는 누락된 항목 다수 존재.

### 변경

`conf/docker/conf/mc-web-console/api/conf/api.yaml`에 mc-iam-manager 누락 항목 추가:

| 분류 | 추가된 operationId |
|------|-------------|
| 인증 | `Signup` |
| CSP Role | `GetCspRoleById`, `CreateCspRole`, `DeleteCspRole` |
| CSP Policy | `listCspPolicies`, `GetCspPolicyById`, `CreateCspPolicy`, `UpdateCspPolicy`, `DeleteCspPolicy`, `GetPoliciesByRoleId`, `AttachPolicyToRole`, `DetachPolicyFromRole`, `SyncCspPolicies` |
| 메뉴 CRUD | `Listmenustree`, `Createmenu`, `Getmenubyid`, `Updatemenu`, `Deletemenu` |
| 사용자 관리 | `UpdateUserStatus`, `ResetUserPassword`, `ChangeMyPassword` |
| Organization | `Createorganization`, `Getorganizations`, `Getorganizationbyid`, `Getorganizationbycode`, `Updateorganization`, `Deleteorganization`, `Getorganizationusers`, `Assignuserorganizations`, `Getuserorganizations`, `Removeuserorganization` |
| CSP 계정 | `listCspAccounts`, `createCspAccount`, `getCspAccountByID`, `updateCspAccount`, `deleteCspAccount`, `validateCspAccount`, `activateCspAccount`, `deactivateCspAccount` |
| Setup/Sync | `GetProjectSyncDiff`, `ApplyProjectSync`, `listMenus`, `InitialMenus`, `SyncMcmpApis`, `syncProjects` |

`Createuser.resourcePath` 경로 오류 수정: `/api/user` → `/api/users`
