### PR TITLE
Make mc-infra-manager work and be initialized

### DIFF
--- a/conf/docker/conf/mc-infra-manager/assets/azure-publisher-filters.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/azure-publisher-filters.yaml
@@ -1,0 +1,78 @@
+# Azure Publisher Filtering Configuration
+# This file controls which Azure publishers are included/excluded when fetching VM images
+# Enables performance optimization by filtering out test/unofficial publishers
+
+# Enable/Disable publisher filtering globally
+publisherFiltering:
+  enabled: true
+  # Strategy: "whitelist" (only include specified) or "blacklist" (exclude specified)
+  strategy: "whitelist"
+
+# Official Microsoft and Partner Publishers (from Microsoft Learn)
+# Reference: https://learn.microsoft.com/en-us/azure/virtual-machines/linux/endorsed-distros
+# Additional reference (HPC Ubuntu image):
+# https://learn.microsoft.com/ko-kr/azure/virtual-machines/configure#ubuntu-hpc-vm-images
+# Additional reference (default/popular image publisher examples):
+# https://learn.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage
+# https://learn.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage
+whitelistedPublishers:
+  # Microsoft Official
+  - "Microsoft"
+  - "MicrosoftWindowsServer"
+  - "MicrosoftWindowsDesktop"
+  - "Microsoft-DSVM"            # Ubuntu-HPC official doc example
+  - "MicrosoftVisualStudio"     # Windows default image doc example
+  - "microsoft-ads"             # Data Science VM (Windows) doc example
+  - "MicrosoftSQLServer"
+  - "MicrosoftSharePoint"
+  - "MicrosoftDynamicsAX"
+  
+  # Linux Distributions - Official Partners
+  - "Canonical"                 # Ubuntu
+  - "RedHat"                     # Red Hat Enterprise Linux
+  - "SUSE"                       # SUSE Linux Enterprise Server
+  - "CIQ"                        # Rocky Linux
+  - "Credativ"                   # Debian
+  - "AlmaLinux"                  # AlmaLinux OS
+  - "Oracle"                     # Oracle Linux
+  - "Kinvolk"                    # Flatcar Container Linux
+  - "OpenLogic"                  # CentOS (legacy)
+  - "RockyLinux"                 # Rocky (alternative publisher)
+  - "Debian"                     # Debian (if exists as publisher)
+  - "Ubuntu"                     # Ubuntu (alternative forms)
+  
+  # Additional recognized publishers
+  - "Citrix"                     # Citrix solutions
+  - "Bitnami"                    # Application stacks
+  - "Canonical.UbuntuAdvantaged" # Ubuntu Advantage variant
+
+# Test/Unofficial publishers to explicitly exclude
+# Used for reference and debugging
+blacklistedPatterns:
+  - "*test*"
+  - "*local*"
+  - "*demo*"
+  - "*vincenttest*"
+  - "*workloadinsights*"
+  - "*timestamp*"               # Publishers with timestamps in names (personal tests)
+  - "*corp*ai*"                 # Corporation AI test images
+  - "*inc*"                     # Individual/startup test publishers
+
+# Publisher inclusion rules (if using pattern matching)
+# These can be enabled in code as fallback when publisher not in whitelist
+inclusionRules:
+  # Allow publishers that have significant image count
+  minImageCountThreshold: 1  # require at least 1 image
+  
+  # Allow well-known prefixes
+  wellKnownPrefixes:
+    - "Microsoft"
+    - "Canonical"
+    - "RedHat"
+    - "SUSE"
+    - "Oracle"
+
+# Debug settings
+debug:
+  logFilteredPublishers: false   # Log publishers that are filtered out
+  logIncludedPublishers: false   # Log publishers that are included

--- a/conf/docker/conf/mc-infra-manager/assets/k8sclusterinfo.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/k8sclusterinfo.yaml
@@ -22,20 +22,20 @@ k8scluster:
     requiredSubnetCount: 2
     version:
       - region: [common]
-        available:
+        available: # Updated: 2026-05-11 (verified with aws eks describe-cluster-versions --region ap-northeast-2)
+          - name: "1.35"
+            id: "1.35"
+          - name: "1.34"
+            id: "1.34"
           - name: "1.33"
             id: "1.33"
-          - name: "1.32"
-            id: "1.32"
-          - name: "1.31"
-            id: "1.31"
-          # Deprecated versions (not available in AWS console as of 2025-08)  
+          # Deprecated versions (not available in AWS console as of 2026-05)
+          # - name: "1.32"
+          #   id: "1.32"
+          # - name: "1.31"
+          #   id: "1.31"
           # - name: "1.30"
           #   id: "1.30"
-          # - name: "1.29"
-          #   id: "1.29"
-          # - name: "1.28"
-          #   id: "1.28"
     rootDisk:
       - region: [common]
         type:
@@ -116,8 +116,10 @@ k8scluster:
       # ap-northeast-1,ap-northeast-2,ap-southeast-1,ap-southeast-3,ap-southeast-5,us-west-1,us-east-1,eu-central-1,eu-west-1,cn-beijing,cn-hongkong,cn-shanghai,cn-huhehaote,cn-heyuan,cn-wulanchabu,cn-guangzhou
       - region: [common] 
         available:
+          - name: "1.35"
+            id: "1.35.2-aliyun.1"
           - name: "1.34"
-            id: "1.34.1-aliyun.1"
+            id: "1.34.3-aliyun.1"
           - name: "1.33"
             id: "1.33.3-aliyun.1"
           - name: "1.32"

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-aws/cloud-init-ubuntu
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-aws/cloud-init-ubuntu
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+USER="cb-user"
+HOME_DIR="/home/${USER}"
+SSH_DIR="${HOME_DIR}/.ssh"
+AUTH_KEYS="${SSH_DIR}/authorized_keys"
+IMDS="http://169.254.169.254"
+
+# 1) Create cb-user
+id -u "$USER" &>/dev/null || useradd -m -s /bin/bash -G sudo "$USER"
+
+# 2) Create .ssh directory and set permissions
+install -d -m 700 -o "$USER" -g "$USER" "$SSH_DIR"
+
+# 3) Retrieve IMDSv2 token
+TOKEN="$(curl -sS -X PUT "${IMDS}/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+
+# 4) Fetch public key (when a Key Pair is attached to the instance)
+#    Use -f so it fails immediately on error
+curl -sSf -H "X-aws-ec2-metadata-token: ${TOKEN}" \
+  "${IMDS}/latest/meta-data/public-keys/0/openssh-key" > "$AUTH_KEYS"
+
+# 5) Set permissions and ownership
+chmod 600 "$AUTH_KEYS"
+chown -R "$USER:$USER" "$HOME_DIR"
+
+# 6) Allow passwordless sudo (sudoers.d recommended)
+echo "${USER} ALL=(ALL:ALL) NOPASSWD: ALL" > "/etc/sudoers.d/${USER}"
+chmod 440 "/etc/sudoers.d/${USER}"
+

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-aws/cloud-init-windows
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-aws/cloud-init-windows
@@ -1,0 +1,4 @@
+<powershell>
+net user "administrator" "*PASSWORD*"
+</powershell>
+<persist>true</persist>

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-common/cloud-init
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-common/cloud-init
@@ -1,0 +1,7 @@
+#!/bin/bash
+#### add Cloud-Barista user
+useradd -s /bin/bash cb-user -rm -G sudo;
+mkdir /home/cb-user/.ssh; 
+curl -s `cloud-init query subplatform | sed 's/metadata (//g' | sed 's/)//g'`/latest/meta-data/public-keys/0/openssh-key > /home/cb-user/.ssh/authorized_keys;
+chown -R cb-user:cb-user /home/cb-user;
+echo "cb-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ibm/cloud-init
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ibm/cloud-init
@@ -1,0 +1,12 @@
+#cloud-config
+users:
+  - default
+  - name: {{username}}
+    groups: sudo
+    shell: /bin/bash
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+
+runcmd:
+  - cp -r /root/.ssh /home/{{username}}
+  - chown -R {{username}}:{{username}} /home/{{username}}/.ssh
+  - /bin/bash -c 'str=`cat /home/{{username}}/.ssh/authorized_keys`; delimiter=ssh-rsa; s=$str$delimiter; splitStr=(); while [[ $s ]]; do splitStr+=( "${s%%"$delimiter"*}" ); s=${s#*"$delimiter"}; done; echo $delimiter${splitStr[1]} > /home/{{username}}/.ssh/authorized_keys;'

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-kt/cloud-init
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-kt/cloud-init
@@ -1,0 +1,7 @@
+#!/bin/bash
+#### add Cloud-Barista user
+useradd -s /bin/bash {{username}} -rm -G sudo;
+chown -R {{username}}:{{username}} /home/{{username}};
+echo "{{username}} ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;
+cp -r /root/.ssh /home/{{username}};
+chown -R {{username}}:{{username}} /home/{{username}}/.ssh;

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-kt/cloud-init-centos
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-kt/cloud-init-centos
@@ -1,0 +1,9 @@
+#!/bin/bash
+#### add Cloud-Barista user
+adduser {{username}}
+usermod -aG wheel 
+chown -R {{username}}:{{username}} /home/{{username}};
+echo "{{username}} ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;
+mkdir /home/{{username}}/.ssh;
+echo "{{public_key}}"> /home/{{username}}/.ssh/authorized_keys;
+chown -R {{username}}:{{username}} /home/{{username}}/.ssh/authorized_keys;

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-kt/cloud-init-ubuntu
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-kt/cloud-init-ubuntu
@@ -1,0 +1,8 @@
+#!/bin/bash
+#### add Cloud-Barista user
+useradd -s /bin/bash {{username}} -rm -G sudo;
+chown -R {{username}}:{{username}} /home/{{username}};
+echo "{{username}} ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;
+mkdir /home/{{username}}/.ssh;
+echo "{{public_key}}"> /home/{{username}}/.ssh/authorized_keys;
+chown -R {{username}}:{{username}} /home/{{username}}/.ssh/authorized_keys;

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-kt/cloud-init-windows
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-kt/cloud-init-windows
@@ -1,0 +1,4 @@
+<powershell>
+net user "Administrator" "{{PASSWORD}}"
+</powershell>
+<persist>true</persist>

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ktcloud/cloud-init-centos
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ktcloud/cloud-init-centos
@@ -1,0 +1,9 @@
+#!/bin/bash
+#### add Cloud-Barista user
+adduser {{username}}
+usermod -aG wheel 
+chown -R {{username}}:{{username}} /home/{{username}};
+echo "{{username}} ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;
+mkdir /home/{{username}}/.ssh;
+echo "{{public_key}}"> /home/{{username}}/.ssh/authorized_keys;
+chown -R {{username}}:{{username}} /home/{{username}}/.ssh/authorized_keys;

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ktcloud/cloud-init-rocky
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ktcloud/cloud-init-rocky
@@ -1,0 +1,15 @@
+#!/bin/bash
+#### add Cloud-Barista user
+set -e
+
+useradd -m -s /bin/bash -G wheel "{{username}}"
+
+echo "{{username}} ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/{{username}}"
+chmod 0440 "/etc/sudoers.d/{{username}}"
+
+install -d -m 0700 -o "{{username}}" -g "{{username}}" "/home/{{username}}/.ssh"
+echo "{{public_key}}" > "/home/{{username}}/.ssh/authorized_keys"
+chown "{{username}}:{{username}}" "/home/{{username}}/.ssh/authorized_keys"
+chmod 0600 "/home/{{username}}/.ssh/authorized_keys"
+
+chown -R "{{username}}:{{username}}" "/home/{{username}}"

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ktcloud/cloud-init-ubuntu
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ktcloud/cloud-init-ubuntu
@@ -1,0 +1,8 @@
+#!/bin/bash
+#### add Cloud-Barista user
+useradd -s /bin/bash {{username}} -rm -G sudo;
+chown -R {{username}}:{{username}} /home/{{username}};
+echo "{{username}} ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;
+mkdir /home/{{username}}/.ssh;
+echo "{{public_key}}"> /home/{{username}}/.ssh/authorized_keys;
+chown -R {{username}}:{{username}} /home/{{username}}/.ssh/authorized_keys;

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ktcloud/cloud-init-windows
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ktcloud/cloud-init-windows
@@ -1,0 +1,4 @@
+<powershell>
+net user "Administrator" "{{PASSWORD}}"
+</powershell>
+<persist>true</persist>

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ncp/cloud-init
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ncp/cloud-init
@@ -1,0 +1,8 @@
+#!/bin/bash
+#### add Cloud-Barista user
+useradd -s /bin/bash {{username}} -rm -G sudo;
+chown -R {{username}}:{{username}} /home/{{username}};
+echo "{{username}} ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;
+mkdir /home/{{username}}/.ssh;
+echo "{{public_key}}"> /home/{{username}}/.ssh/authorized_keys;
+chown -R {{username}}:{{username}} /home/{{username}}/.ssh/authorized_keys;

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ncp/cloud-init-centos
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ncp/cloud-init-centos
@@ -1,0 +1,9 @@
+#!/bin/bash
+#### add Cloud-Barista user
+adduser {{username}}
+usermod -aG wheel 
+chown -R {{username}}:{{username}} /home/{{username}};
+echo "{{username}} ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;
+mkdir /home/{{username}}/.ssh;
+echo "{{public_key}}"> /home/{{username}}/.ssh/authorized_keys;
+chown -R {{username}}:{{username}} /home/{{username}}/.ssh/authorized_keys;

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ncp/cloud-init-windows
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-ncp/cloud-init-windows
@@ -1,0 +1,4 @@
+Dim shell
+Set shell= WScript.CreateObject ("WScript.shell")
+shell.Exec "net user Administrator {{PASSWORD}}"
+Set shell= Nothing

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-nhn/cloud-init-ubuntu
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-nhn/cloud-init-ubuntu
@@ -1,0 +1,11 @@
+#cloud-config
+users:
+  - name: {{username}}
+    ssh-authorized-keys:
+      - {{public_key}}
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    groups: sudo
+    shell: /bin/bash
+runcmd:
+  - sed -i -e '$aAllowUsers {{username}}' /etc/ssh/sshd_config
+  - restart ssh

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-nhn/cloud-init-windows
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-nhn/cloud-init-windows
@@ -1,0 +1,6 @@
+<powershell>
+#ps1_sysnative
+New-LocalUser "{{username}}" -Password (ConvertTo-SecureString "{{PASSWORD}}" -AsPlainText -Force)
+Add-LocalGroupMember -Group "Administrators" -Member "{{username}}"    
+</powershell>
+<persist>true</persist>

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-openstack/cloud-init
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-openstack/cloud-init
@@ -1,0 +1,11 @@
+#cloud-config
+users:
+  - name: {{username}}
+    ssh-authorized-keys:
+      - {{public_key}}
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    groups: sudo
+    shell: /bin/bash
+runcmd:
+  - sed -i -e '$aAllowUsers {{username}}' /etc/ssh/sshd_config
+  - restart ssh

--- a/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-tencent/cloud-init
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/.cloud-init-tencent/cloud-init
@@ -1,0 +1,8 @@
+#!/bin/bash
+#### add Cloud-Barista user
+useradd -s /bin/bash cb-user -rm -G sudo;
+mkdir /home/cb-user/.ssh; 
+cp -r /root/.ssh/ /home/cb-user/;
+cp -r /home/ubuntu/.ssh/ /home/cb-user/;
+chown -R cb-user:cb-user /home/cb-user;
+echo "cb-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;

--- a/conf/docker/conf/mc-infra-manager/assets/spider/README.md
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/README.md
@@ -1,0 +1,43 @@
+# CB-Spider Cloud Driver Libs
+
+This directory contains configuration files originally from
+[cb-spider/cloud-driver-libs](https://github.com/cloud-barista/cb-spider/tree/master/cloud-driver-libs),
+managed locally within CB-Tumblebug.
+
+## Why not in the container image?
+
+Starting from CB-Spider 0.12.8, the Docker image no longer includes `cloud-driver-libs/`
+(static mode optimization). However, these files are still required at runtime for:
+
+- **VM provisioning** — cloud-init scripts (`.cloud-init-*`) are injected during VM creation
+- **Root disk configuration** — `cloudos_meta.yaml` provides CSP-specific disk type/size metadata
+- **CSP registry** — `cloudos.yaml` lists supported cloud providers
+
+Since CB-Tumblebug administrators may need to customize some of these files
+(e.g., cloud-init scripts for specific deployment environments or CSP-specific settings),
+they are maintained here rather than embedded in the container image.
+
+This directory is mounted into the CB-Spider container via `docker-compose.yaml`:
+
+```yaml
+volumes:
+  - ./assets/spider/:/root/go/src/github.com/cloud-barista/cb-spider/cloud-driver-libs/
+```
+
+## Updating
+
+When upgrading the CB-Spider version in `docker-compose.yaml`, update this directory
+by copying from the corresponding version of cb-spider:
+
+```bash
+# Example: sync with cb-spider source
+cp -r <cb-spider-source>/cloud-driver-libs/* assets/spider/
+```
+
+## Directory Structure
+
+| Path | Description |
+|------|-------------|
+| `cloudos_meta.yaml` | CSP metadata (credentials, disk types, region defaults) |
+| `cloudos.yaml` | List of supported cloud providers |
+| `.cloud-init-*/` | Per-CSP cloud-init scripts for VM initialization |

--- a/conf/docker/conf/mc-infra-manager/assets/spider/cloudos.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/cloudos.yaml
@@ -1,0 +1,26 @@
+# Cloud Driver Manager of CB-Spider.
+# The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+# The CB-Spider Mission is to connect all the clouds with a single interface.
+#
+#      * Cloud-Barista: https://github.com/cloud-barista
+#
+# by CB-Spider Team, 2021.11.
+# by CB-Spider Team, 2020.11.
+# by CB-Spider Team, 2020.03.
+
+### List of support CloudOS.
+cloudos:
+  - AWS
+  - AZURE
+  - GCP
+  - ALIBABA
+  - TENCENT
+  - IBM
+  - OPENSTACK
+  - NCP
+  - NHN
+  - KT
+  - KTCLASSIC
+#--- Emulation
+  - MOCK
+#  - CLOUDTWIN

--- a/conf/docker/conf/mc-infra-manager/assets/spider/cloudos_meta.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/spider/cloudos_meta.yaml
@@ -1,0 +1,149 @@
+# The CB-Spider Mission is to connect all the clouds with a single interface.
+#
+#      * Cloud-Barista: https://github.com/cloud-barista
+#
+# by CB-Spider Team, 2021.10.
+
+### Meta info of CloudOS
+
+AWS:
+  region: Region / Zone
+  credential: ClientId / ClientSecret
+  credentialcsp: aws_access_key_id / aws_secret_access_key
+  # rootdisktype: standard / io1 / io2 / gp2 / sc1 / st1 / gp3
+  # issues: https://github.com/cloud-barista/cb-spider/pull/523#issuecomment-965363272
+  rootdisktype: standard / gp2 / gp3
+  disktype: standard / gp2 / gp3 / io1 / io2 / st1 / sc1
+  disksize: standard|1|1024|GB / gp2|1|16384|GB / gp3|1|16384|GB / io1|4|16384|GB / io2|4|16384|GB / st1|125|16384|GB / sc1|125|16384|GB
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 255 / 256 / 255 / 255 / 255 / 256 / 32 / 127 / 100
+  defaultregiontoquery: ap-northeast-2 / ap-northeast-2a
+
+AZURE:
+  region: Region / Zone
+  credential: ClientId / ClientSecret / TenantId / SubscriptionId
+  credentialcsp: clientId / clientSecret / tenantId / subscriptionId
+  # type issues: https://github.com/cloud-barista/cb-spider/pull/529#issue-1051678985
+  rootdisktype: PremiumSSD / StandardSSD / StandardHDD
+  disktype: PremiumSSD / StandardSSD / StandardHDD
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 64 / 80 / 64 / 80 / 64 / 80 / 80 / 80 / 63
+  defaultregiontoquery: koreacentral / 1
+
+GCP:
+  region: Region / Zone
+  credential: PrivateKey / ProjectID / ClientEmail
+  credentialcsp: private_key / project_id / client_email
+  rootdisktype: pd-standard / pd-balanced / pd-ssd / pd-extreme
+  disktype: pd-standard / pd-balanced / pd-ssd / pd-extreme
+  disksize: pd-standard|10|65536|GB / pd-balanced|10|65536|GB / pd-ssd|10|65536|GB / pd-extreme|500|65536|GB
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  #idmaxlength: 63 / 63 / 63 / 0 / 63
+  idmaxlength: 63 / 63 / 57 / 0 / 63 / 63 / 63 / 63 / 40
+
+ALIBABA:
+  region: Region / Zone
+  credential: ClientId / ClientSecret
+  credentialcsp: AccessKeyId / AccessKeySecret
+  rootdisktype: cloud_essd / cloud_efficiency / cloud / cloud_ssd
+  #rootdisktype: cloud_efficiency / cloud / cloud_ssd
+  rootdisksize: cloud_essd|20|32768|GB / cloud_efficiency|20|32768|GB / cloud|5|2000|GB / cloud_ssd|20|32768|GB
+  #rootdisksize: cloud_efficiency|20|32768|GB / cloud|5|2000|GB / cloud_ssd|20|32768|GB
+  disktype: cloud / cloud_efficiency / cloud_ssd / cloud_essd
+  disksize: cloud|5|2000|GB / cloud_efficiency|20|32768|GB / cloud_ssd|20|32768|GB / cloud_essd_PL0|40|32768|GB / cloud_essd_PL1|20|32768|GB / cloud_essd_PL2|461|32768|GB / cloud_essd_PL3|1261|32768|GB
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 128 / 128 / 128 / 128 / 128 / 128 / 80 / 128 / 63
+  defaultregiontoquery: ap-northeast-2 / ap-northeast-2a
+
+TENCENT:
+  region: Region / Zone
+  credential: ClientId / ClientSecret
+  credentialcsp: SecretId / SecretKey
+  #rootdisktype: CLOUD_PREMIUM / LOCAL_BASIC / LOCAL_SSD / CLOUD_BASIC / CLOUD_SSD
+  rootdisktype: CLOUD_PREMIUM / CLOUD_SSD
+  rootdisksize: CLOUD_PREMIUM|50|16000|GB / CLOUD_SSD|50|16000|GB
+  disktype: CLOUD_PREMIUM / CLOUD_SSD / CLOUD_HSSD / CLOUD_BASIC / CLOUD_TSSD
+  disksize: CLOUD_PREMIUM|10|32000|GB / CLOUD_SSD|20|32000|GB / CLOUD_HSSD|20|32000|GB / CLOUD_BASIC|10|32000|GB / CLOUD_TSSD|10|32000|GB
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 60 / 60 / 60 / 25 / 88 / 60 / 60 / 60 / 50
+  defaultregiontoquery: ap-seoul / ap-seoul-1
+
+IBM:
+  region: Region / Zone
+  credential: ApiKey
+  credentialcsp: ApiKey
+  rootdisktype: general-purpose / sdp
+  rootdisksize: general-purpose|100|250|GB / sdp|100|250|GB
+  disktype: general-purpose / 5iops-tier / 10iops-tier / sdp
+  disksize: general-purpose|10|16000|GB / 5iops-tier|10|9600|GB / 10iops-tier|10|4800|GB / sdp|1|32000|GB
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 63 / 63 / 63 / 63 / 63 / 63 / 63 / 63 / 32 / 63
+  defaultregiontoquery: us-south / us-south-1
+
+OPENSTACK:
+  region: Region / Zone
+  credential: IdentityEndpoint / Username / Password / DomainName / ProjectID
+  credentialcsp: IdentityEndpoint / Username / Password / DomainName / ProjectID
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 255 / 255 / 255 / 255 / 255 / 255 / 255 / 255 / 0
+  
+NCP:
+  region: Region / Zone
+  credential: ClientId / ClientSecret
+  credentialcsp: ncloud_access_key / ncloud_secret_key
+  rootdisktype: HDD
+  rootdisksize: HDD|10|2000|GB
+  disktype: SSD / HDD
+  disksize: SSD|100|16380|GB / HDD|100|16380|GB
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 30 / 30 / 30 / 30 / 30 / 30 / 30 / 30 / 20 / 20
+
+NHN:
+  region: Region / Zone
+  credential: IdentityEndpoint / Username / Password / DomainName / TenantId
+  credentialcsp: IdentityEndpoint / Username / Password / DomainName / TenantId
+  rootdisktype: General_HDD / General_SSD
+  rootdisksize: General_HDD|20|1000|GB / General_SSD|20|1000|GB
+  disktype: General_HDD / General_SSD
+  disksize: General_HDD|10|2000|GB / General_SSD|10|2000|GB
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 32 / 32 / 255 / 32 / 90 / 255 / 80 / 255 / 32
+
+KTCLASSIC:
+  region: Region / Zone
+  credential: ClientId / ClientSecret
+  credentialcsp: API_Key / Secret_Key
+  rootdisktype: HDD / SSD
+  rootdisksize: HDD|20|50|GB / SSD|20|50|GB
+  disktype: HDD / SSD-Provisioned
+  disksize: HDD|10|500|GB / SSD-Provisioned|100|800|GB
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster
+  idmaxlength: 30 / 30 / 30 / 100 / 63 / 50 / 30 / 32 / 0
+
+KT:
+  region: Region / Zone
+  credential: IdentityEndpoint / Username / Password / DomainName / ProjectID
+  credentialcsp: IdentityEndpoint / Username / Password / DomainName / ProjectID
+  rootdisktype: HDD / SSD
+  rootdisksize: HDD|50|100|GB / SSD|50|100|GB
+  disktype: HDD / SSD
+  disksize: HDD|10|2000|GB / SSD|10|2000|GB
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 30 / 48 / 30 / 100 / 63 / 50 / 30 / 50 / 0 / 20
+
+#--- Emulation
+
+MOCK:
+  region: Region
+  credential: MockName
+  credentialcsp: MockName
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  idmaxlength: 255 / 255 / 255 / 255 / 255 / 255 / 255 / 255 / 255
+  rootdisktype: SSD /HDD / MEM
+  disktype: SSD / HDD / MEM
+  disksize: SSD|1|16384|GB / HDD|1|16384|GB / MEM|10|512|GB
+
+CLOUDTWIN:
+  region: Region
+  credential: IdentityEndpoint / DomainName / MockName
+  credentialcsp: IdentityEndpoint / DomainName / MockName

--- a/conf/docker/conf/mc-infra-manager/conf/setup.env
+++ b/conf/docker/conf/mc-infra-manager/conf/setup.env
@@ -4,58 +4,75 @@ export TB_ROOT_PATH=`cd $SCRIPT_DIR && cd .. && pwd`
 # Use TB_ROOT_PATH directly if the SCRIPT_DIR does not work
 # export TB_ROOT_PATH=$HOME/go/src/github.com/cloud-barista/cb-tumblebug
 
-# Set API access config
+
+# CB-Tumblebug API Access
 export TB_API_USERNAME=default
 export TB_API_PASSWORD='$2a$10$4PKzCuJ6fPYsbCF.HR//ieLjaCzBAdwORchx62F2JRXQsuR3d9T0q'
 ## TB_ALLOW_ORIGINS (ex: https://cloud-barista.org,http://localhost:8080 or * for all)
 export TB_ALLOW_ORIGINS=*
-## Set TB_AUTH_ENABLED=true currently for basic auth for all routes (i.e., url or path)
+## Set TB_AUTH_ENABLED=true to enable basic auth for all routes
 export TB_AUTH_ENABLED=true
 ## Set TB_AUTH_MODE=basic or jwt
 export TB_AUTH_MODE=basic
 
-## Set TB_SELF_ENDPOINT, to access Swagger API dashboard outside (Ex: export TB_SELF_ENDPOINT=x.x.x.x:1323)
+## Set TB_SELF_ENDPOINT to expose Swagger API dashboard outside (ex: x.x.x.x:1323)
 export TB_SELF_ENDPOINT=localhost:1323
 
-# Set system endpoints
+
+# CB-Spider API Credentials
+# Must match SPIDER_USERNAME/SPIDER_PASSWORD configured in CB-Spider.
+# In docker-compose, both are sourced from SP_API_USERNAME/SP_API_PASSWORD.
+export TB_SPIDER_USERNAME=default
+export TB_SPIDER_PASSWORD=default
+
+
+# Internal Service Endpoints
 export TB_SPIDER_REST_URL=http://localhost:1024/spider
 export TB_DRAGONFLY_REST_URL=http://localhost:9090/dragonfly
-export TB_TERRARIUM_REST_URL=http://localhost:8888/terrarium
-export TB_IAM_MANAGER_REST_URL=https://localhost:5000
+export TB_TERRARIUM_REST_URL=http://localhost:8055/terrarium
+export TB_IAM_MANAGER_REST_URL=http://localhost:5000
 
-## Set internal DB config (POSTGRES)
+
+# MC-Terrarium API Credentials
+export TB_TERRARIUM_API_USERNAME=default
+export TB_TERRARIUM_API_PASSWORD=default
+
+# PostgreSQL (internal metadata DB)
 export TB_POSTGRES_ENDPOINT=localhost:5432
 export TB_POSTGRES_DATABASE=tumblebug
 export TB_POSTGRES_USER=tumblebug
 export TB_POSTGRES_PASSWORD=tumblebug
 
-## Set etcd cluster
+# etcd (CB-Tumblebug metadata store)
 export TB_ETCD_ENDPOINTS=http://localhost:2379
 export TB_ETCD_AUTH_ENABLED=false
 export TB_ETCD_USERNAME=default
 export TB_ETCD_PASSWORD=default
 
-# Set Terrarium API access config
-export TB_TERRARIUM_API_USERNAME=default
-export TB_TERRARIUM_API_PASSWORD=default
 
-## Set period for auto control goroutine invocation
+# OpenBao / Vault (CSP credential secrets management)
+# Persistent mode: run ./init/openbao/openbao-init.sh to get the token after first init.
+# Dev mode:        set VAULT_TOKEN to any value (e.g., root-token).
+export VAULT_ADDR=http://localhost:8200
+export VAULT_TOKEN=
+
+
+# Misc
+## Auto-control goroutine interval (ms)
 export TB_AUTOCONTROL_DURATION_MS=10000
-
-## Set name of default objects
+## Default object names
 export TB_DEFAULT_NAMESPACE=ns01
 export TB_DEFAULT_CREDENTIALHOLDER=admin
 
-## Logger configuration
-# Set log file path (default logfile path: ./log/tumblebug.log) 
+# Logger configuration
 export TB_LOGFILE_PATH=$TB_ROOT_PATH/log/tumblebug.log
 export TB_LOGFILE_MAXSIZE=1000
 export TB_LOGFILE_MAXBACKUPS=3
 export TB_LOGFILE_MAXAGE=30
 export TB_LOGFILE_COMPRESS=false
-# Set log level, such as trace, debug, info, warn, error, fatal, and panic
+# Log level: trace, debug, info, warn, error, fatal, panic
 export TB_LOGLEVEL=debug
-# Set log writer, such as file, stdout, or both
+# Log writer: file, stdout, or both
 export TB_LOGWRITER=both
-# Set execution environment, such as development or production
+# Execution environment: development or production
 export TB_NODE_ENV=development

--- a/conf/docker/conf/mc-infra-manager/openbao-entrypoint.sh
+++ b/conf/docker/conf/mc-infra-manager/openbao-entrypoint.sh
@@ -50,5 +50,15 @@ if ! bao token lookup "$DESIRED_TOKEN" >/dev/null 2>&1; then
   bao token create -id="$DESIRED_TOKEN" -policy=root -orphan -ttl=0 >/dev/null
 fi
 
+# 7) Enable KV v2 secrets engine at secret/ if not already mounted
+# In persistent mode, secret/ is NOT pre-mounted (unlike dev mode).
+if bao secrets list 2>/dev/null | grep -q "^secret/"; then
+  echo "[openbao-entrypoint] KV v2 already enabled at secret/"
+else
+  echo "[openbao-entrypoint] enabling KV v2 secrets engine at secret/..."
+  bao secrets enable -path=secret kv-v2 >/dev/null && \
+    echo "[openbao-entrypoint] KV v2 enabled at secret/"
+fi
+
 echo "[openbao-entrypoint] openbao ready."
 wait "$BAO_PID"

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
 ##### MC-INFRA-CONNECTOR #########################################################################################################################
 
   mc-infra-connector:
-    image: cloudbaristaorg/cb-spider:0.12.18
+    image: cloudbaristaorg/cb-spider:0.12.23
     pull_policy: missing
     container_name: mc-infra-connector
     restart: unless-stopped
@@ -37,19 +37,18 @@ services:
         protocol: tcp
     volumes:
       - ./tool/mcc:/app/tool/mcc
-      - ./conf/mc-infra-connector/:/root/go/src/github.com/cloud-barista/cb-spider/conf/:ro
       - ./container-volume/mc-infra-connector/meta_db/:/root/go/src/github.com/cloud-barista/cb-spider/meta_db/
       - ./container-volume/mc-infra-connector/log/:/root/go/src/github.com/cloud-barista/cb-spider/log/
     environment:
-      - PLUGIN_SW=OFF
       - SERVER_ADDRESS=0.0.0.0:1024
-      # if you leave these values empty, REST Auth will be disabled.
       - SPIDER_USERNAME=${MC_INFRA_CONNECTOR_API_USERNAME:-default}
       - SPIDER_PASSWORD=${MC_INFRA_CONNECTOR_API_PASSWORD:-default}
       - SPIDER_LOG_LEVEL=${MC_INFRA_CONNECTOR_LOG_LEVEL:-error}
       - SPIDER_HISCALL_LOG_LEVEL=${MC_INFRA_CONNECTOR_HISCALL_LOG_LEVEL:-error}
       - ID_TRANSFORM_MODE=OFF
-      - ADMINWEB=ON
+      - PLUGIN_SW=OFF
+      - ADMINWEB=OFF
+      - SPIDER_BACKUP_ENABLED=false
     healthcheck: # for CB-Spider
       test: [ "CMD", "/app/tool/mcc", "rest", "get", "http://localhost:1024/spider/readyz" ]
       <<: *default-health-check
@@ -57,7 +56,7 @@ services:
 ##### MC-INFRA-MANAGER #########################################################################################################################
 
   mc-infra-manager:
-    image: cloudbaristaorg/cb-tumblebug:0.12.9
+    image: cloudbaristaorg/cb-tumblebug:0.12.12
     container_name: mc-infra-manager
     restart: unless-stopped
     pull_policy: missing
@@ -125,7 +124,7 @@ services:
       <<: *default-health-check
 
   mc-infra-manager-etcd:
-    image: gcr.io/etcd-development/etcd:v3.5.21
+    image: gcr.io/etcd-development/etcd:v3.6.11
     container_name: mc-infra-manager-etcd
     restart: unless-stopped
     networks:
@@ -225,6 +224,18 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+
+  # CB-MapUI is a Web-based test client (disable it for production use)
+  cb-mapui:
+    image: cloudbaristaorg/cb-mapui:0.12.34
+    container_name: cb-mapui
+    networks:
+      - mc-infra-manager-network
+    ports:
+      - target: 1324
+        published: 1324
+        protocol: tcp
+    restart: unless-stopped
 
 
 ##### MC-IAM-MANAGER #########################################################################################################################
@@ -1435,4 +1446,6 @@ services:
         fi
         curl -k -s https://127.0.0.1:8443
         STATUS=`echo $$?`
-        if [ $$STATUS != 0 
+        if [ $$STATUS != 0 ] && [ $$STATUS != 52 ]; then
+          exit 1
+        fi


### PR DESCRIPTION
(이슈)
기존에는 CB-Tumblebug, CB-Spider 관련 설정 누락 등에 의해서,
인프라 초기화 (assets, credential) 설정이 되지 않는 상태였습니다.

(제안)
이 PR 은 해당 이슈들을 전반적으로 검토하고,
mc-admin-cli 로 구동된 CB-Tumblebug 가 정상 동작하는 것까지 확인하였습니다. (주로 openbao config, asset 불충분 이슈)

참고: cb-mapui 는 CB-Tumblebug의 정상 초기화 확인, 인프라 생성 테스트 등을 위해서, 임시로 compose에 추가하였습니다. 
(1324 포트로 접속 가능)

아울러, API 변경이나 breaking change 가 없는, 최신 안정화 버전을 m-cmp에 반영하였습니다.

- cb-spider:0.12.23
- cb-tumblebug:0.12.12
- etcd:v3.6.11

<img width="1156" height="656" alt="image" src="https://github.com/user-attachments/assets/dd544b79-afde-4703-8310-12aef5e4c708" />

(참고)
- 추가로, compose 구성에 grafana health-check 부분에 오류가 있길래 수정하였습니다.
- jenkins 가 unhealthy 였었는데.. 제 로컬에서는 수정을 해서, healthy 로 만들어 두긴 했으나, PR에는 포함하지 않았습니다. 
