### PR TITLE
feat: add proxy timeout 600s in nginx http block for long-running APIs

### DIFF
--- a/conf/docker/conf/mc-iam-manager/nginx.template.conf
+++ b/conf/docker/conf/mc-iam-manager/nginx.template.conf
@@ -23,6 +23,11 @@ http {
 
     gzip on;
 
+    # Proxy timeout settings for long-running operations (10 minutes)
+    proxy_connect_timeout 600s;
+    proxy_send_timeout 600s;
+    proxy_read_timeout 600s;
+
     # SSL configuration
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384;

--- a/conf/docker/conf/mc-iam-manager/nginx.template.local.conf
+++ b/conf/docker/conf/mc-iam-manager/nginx.template.local.conf
@@ -25,6 +25,11 @@ http {
 
     gzip on;
 
+    # Proxy timeout settings for long-running operations (10 minutes)
+    proxy_connect_timeout 600s;
+    proxy_send_timeout 600s;
+    proxy_read_timeout 600s;
+
     # Main entry: IAM + Keycloak on HTTP port 80
     server {
         listen 80;


### PR DESCRIPTION
Timeout 60s to 600s