### PR TITLE
Use cb-tumblebug v0.12.15

### DIFF
--- a/conf/docker/conf/mc-infra-manager/assets/cloudimage.csv
+++ b/conf/docker/conf/mc-infra-manager/assets/cloudimage.csv
@@ -39,3 +39,13 @@ AWS,all,WINDOWS_CORE_2025_x86_64,Windows Server 2025,"EKS Node - Windows Server 
 GCP,all,COS_CONTAINERD,Container-Optimized OS,"GKE Node - COS, containerd, x86_64/ARM64",,k8s,x86_64,COS_CONTAINERD
 GCP,all,UBUNTU_CONTAINERD,Ubuntu 22.04 LTS,"GKE Node - Ubuntu 22.04, containerd, x86_64/ARM64",,k8s,x86_64,UBUNTU_CONTAINERD
 GCP,all,WINDOWS_LTSC_CONTAINERD,Windows Server 2019 LTSC,"GKE Node - Windows Server 2019 LTSC, containerd, x86_64",,k8s,x86_64,WINDOWS_LTSC_CONTAINERD
+TENCENT,all,tlinux4_x86_64_public,TencentOS Server 4,"TKE Node - TencentOS Server 4, x86_64",,k8s,x86_64,tlinux4_x86_64_public
+TENCENT,all,tlinux3.1x86_64,TencentOS Server 3.1 (TK4),"TKE Node - TencentOS Server 3.1 (TK4), x86_64",,k8s,x86_64,tlinux3.1x86_64
+TENCENT,all,tlinux2.4(tkernel4)x86_64_HCC,TencentOS Server 2.4 (TK4) HCC,"TKE Node - TencentOS Server 2.4 (TK4) HCC, x86_64",,k8s,x86_64,tlinux2.4(tkernel4)x86_64_HCC
+TENCENT,all,tlinux2.4(tkernel4)x86_64,TencentOS Server 2.4 (TK4),"TKE Node - TencentOS Server 2.4 (TK4), x86_64",,k8s,x86_64,tlinux2.4(tkernel4)x86_64
+TENCENT,all,tlinux2.4x86_64,TencentOS Server 2.4,"TKE Node - TencentOS Server 2.4 (legacy), x86_64",,k8s,x86_64,tlinux2.4x86_64
+TENCENT,all,centos7.8.0_x64,CentOS 7.8,"TKE Node - CentOS 7.8, x86_64",,k8s,x86_64,centos7.8.0_x64
+TENCENT,all,centos8.0x86_64,CentOS 8.0,"TKE Node - CentOS 8.0, x86_64 (Beta)",,k8s,x86_64,centos8.0x86_64
+TENCENT,all,ubuntu20.04x86_64,Ubuntu 20.04,"TKE Node - Ubuntu 20.04, x86_64 (Beta)",,k8s,x86_64,ubuntu20.04x86_64
+TENCENT,all,ubuntu22.04x86_64,Ubuntu 22.04,"TKE Node - Ubuntu 22.04, x86_64",,k8s,x86_64,ubuntu22.04x86_64
+TENCENT,all,redhat7.9x86_64,Red Hat Enterprise Linux 7.9,"TKE Node - Red Hat Enterprise Linux 7.9, x86_64",,k8s,x86_64,redhat7.9x86_64

--- a/conf/docker/conf/mc-infra-manager/assets/cloudimage_ignore.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/cloudimage_ignore.yaml
@@ -1,0 +1,63 @@
+# Cloud Image Ignore Configuration
+# Defines patterns for images that should be skipped during image fetching operations.
+# Matched images are dropped during fetch, before any conversion or storage in DB.
+# Pattern matching is case-insensitive and supports * and ? wildcards and [abc] character classes.
+
+# Global patterns that apply to all CSPs
+global:
+  patterns: []
+
+# CSP-specific ignore patterns
+csps:
+  aws:
+    description: "AWS image ignore patterns"
+    global_patterns:
+      # ── Managed-service / internal AMIs (not for direct EC2/EKS provisioning) ──
+      - "*parallelcluster*"          # AWS ParallelCluster AMIs — HPC cluster orchestration tool only, not for general VM use
+      - "*elasticbeanstalk*"         # Elastic Beanstalk PaaS AMIs — managed by EB service, not for direct VM use
+      - "*-ecs-*"                    # ECS-optimized AMIs — ECS container worker nodes (distinct from EKS), not for general VM use
+      - "*ecs*optimized*"            # Windows ECS Optimized AMIs — underscore format not caught by *-ecs-*
+      - "*ecs-managed-instances*"    # ECS managed node images — ECS internal managed images
+      - "*lambda-managed-instances*" # Lambda internal worker images — not for user VM creation
+      - "*lambda-elevator*"          # Lambda microVM internal worker images — AWS internal use only
+      - "*storage*gateway*"          # AWS Storage Gateway appliance AMIs — virtual storage appliance, not for general VM use
+      - "*datasync*"                 # AWS DataSync appliance AMIs — managed data transfer service, not for general VM use
+      - "*cloud9*"                   # AWS Cloud9 IDE AMIs — cloud IDE environment, not for general VM use
+      - "*dcv-*"                     # NICE DCV AMIs — remote visualization streaming tool, not for general VM use
+      # ── EKS managed node group AMIs ──────────────────────────────────────────
+      # EKS managed node groups select images via AMI type (NodegroupAmiType,
+      # e.g. AL2023_x86_64_STANDARD, BOTTLEROCKET_x86_64), not by explicit AMI
+      # ID — AWS resolves the actual AMI internally at node group creation.
+      # Skipped here as they are not selected via direct image ID lookup.
+      - "amazon-eks-node-*"          # EKS-optimized AL2 / AL2023 node AMIs
+      - "amazon-eks-gpu-node-*"      # EKS-optimized GPU node AMIs (nvidia, neuron)
+      - "bottlerocket-aws-k8s-*"     # Bottlerocket OS AMIs for EKS node groups
+      # ── EKS Auto Mode internal AMIs ───────────────────────────────────────
+      # AWS-managed automatically in EKS Auto Mode; users cannot specify these
+      # AMI IDs in launch templates or node groups. Variants: standard, nvidia,
+      # neuron, amdgpu, amd. Pattern covers all K8s versions and architectures.
+      - "eks-auto-*"
+      # ── Mac dedicated-host AMIs ───────────────────────────────────────────────
+      # Only usable on mac1/mac2 dedicated hardware, not standard EC2 instances.
+      - "*amzn-ec2-macos*"           # Amazon macOS AMIs (arm64_mac / x86_64_mac)
+      - "*macos*sonoma*"             # macOS Sonoma
+      - "*macos*ventura*"            # macOS Ventura
+      - "*macos*monterey*"           # macOS Monterey
+      # ── Ubuntu pre-release / testing builds ───────────────────────────────────
+      # Unstable daily or testing images — not suitable for production VM/EKS use.
+      - "*images-testing*"           # Ubuntu images-testing path (pre-release)
+      - "*ubuntu*daily*"             # Ubuntu daily builds
+      # ── EOL operating systems ─────────────────────────────────────────────────
+      # Past vendor end-of-life: no security patches available.
+      - "*ubuntu*14.04*"             # Ubuntu 14.04 LTS — EOL Apr 2019
+      - "*ubuntu*16.04*"             # Ubuntu 16.04 LTS — EOL Apr 2021
+      - "*ubuntu*18.04*"             # Ubuntu 18.04 LTS — EOL Apr 2023
+      - "*-debian-9-*"               # Debian 9 Stretch — EOL Jun 2022
+      - "*debian*stretch*"           # Debian 9 Stretch (name variant)
+      - "*-debian-10-*"              # Debian 10 Buster — EOL Jun 2024
+      - "*debian*buster*"            # Debian 10 Buster (name variant)
+      - "*rhel-7*"                   # RHEL 7 — EOL Jun 2024
+      - "*rhel7*"                    # RHEL 7 (no-dash variant)
+      - "*sles-12*"                  # SUSE Linux Enterprise 12 — EOL Oct 2024
+      - "*sles12*"                   # SUSE Linux Enterprise 12 (no-dash variant)
+    regions: {}

--- a/conf/docker/conf/mc-infra-manager/assets/extractionpatterns.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/extractionpatterns.yaml
@@ -181,6 +181,52 @@ extractionPatterns:
     - "caffe"
     - "machine learning"
     - "optimized-for-ml"
+
+  # GPU image exclusion patterns (case-insensitive, any match overrides gpuPatterns → not GPU)
+  gpuExcludePatterns:
+    - "nhncloud_allow_gpu_flavor:false"           # NHN: property key indicating GPU NOT allowed
+    - "workloads on vms that have attached gpus"  # GCP: gVNIC description mentioning GPUs incidentally
+
+  # Rules for identifying basic GPU images per CSP
+  # Follows the same include/exclude wildcard logic as basicImageRules
+  basicGpuImageRules:
+    common:
+      include: []
+      exclude:
+        - "*windows*"   # Exclude Windows-based GPU images from basic selection
+    cspSpecific:
+      aws:
+        include:
+          - "*deep learning*nvidia*gpu ami*ubuntu*"  # AWS Deep Learning AMI (DLAMI) Ubuntu — single-VM GPU use
+      gcp:
+        include:
+          - "*deeplearning-platform-release*"   # Google Deep Learning VM (CUDA/PyTorch/TF)
+          - "*ubuntu-os-accelerator-images*"    # Ubuntu + NVIDIA driver
+          - "*rocky-linux-accelerator-cloud*"   # Rocky Linux + NVIDIA driver
+          - "*ml-images*"                       # Google ML-optimized images
+      azure:
+        include:
+          - "*microsoft-dsvm:ubuntu-hpc*"   # Ubuntu HPC (GPU-optimized)
+          - "*microsoft-dsvm:ubuntu-2004*"  # DSVM Ubuntu 20.04
+          - "*microsoft-dsvm:ubuntu-2204*"  # DSVM Ubuntu 22.04
+      ibm:
+        include:
+          - "*red hat enterprise linux ai*nvidia*"  # RHEL AI for NVIDIA accelerators
+      alibaba:
+        include:
+          - "*ubuntu*gpu*driver*cuda*"   # Ubuntu with NVIDIA GPU Driver and CUDA
+      ncp:
+        include:
+          - "*ubuntu*gpu*"   # Ubuntu GPU image (e.g. ubuntu-24.04-gpu)
+          - "*rocky*gpu*"    # Rocky Linux GPU image
+      kt:
+        include:
+          - "*ubuntu*gpusvr*"   # KT GPU server Ubuntu images (CUDA pre-installed)
+          - "*rocky*gpusvr*"    # KT GPU server Rocky Linux images
+      nhn:
+        include:
+          - "*ubuntu*nvidia*"        # Ubuntu with NVIDIA driver
+          - "*ubuntu*deep learning*" # Ubuntu Deep Learning image
   
   # Kubernetes image identification patterns (case-insensitive, any match = Kubernetes)
   k8sPatterns:

--- a/conf/docker/conf/mc-infra-manager/assets/k8sclusterinfo.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/k8sclusterinfo.yaml
@@ -166,10 +166,11 @@ k8scluster:
       - region: [ap-beijing, ap-chengdu, ap-chongqing, ap-guangzhou, ap-hongkong, ap-nanjing, ap-shanghai]
       - region: [common]
         available:
-          - name: "1.30"
-            id: "1.30.0"
-          - name: "1.28"
-            id: "1.28.3"
+          # Updated: 2026-05-19 (1.30 EOM Feb-2026, 1.28 EOFS Apr-2026 — no new clusters)
+          - name: "1.34"
+            id: "1.34.1"
+          - name: "1.32"
+            id: "1.32.2"
     rootDisk:
       - region: [common]
         type:
@@ -206,15 +207,13 @@ k8scluster:
     requiredSubnetCount: 1
     version:
       - region: [common]
-        available: # Updated: 2025-12-18 (verified from IBM Cloud API via CB-Spider)
+        available: # Updated: 2026-06-12
+          - name: "1.35"
+            id: "1.35.5"
           - name: "1.34"
-            id: "1.34.2"
+            id: "1.34.8"
           - name: "1.33"
-            id: "1.33.6"
-          - name: "1.32"
-            id: "1.32.10"
-          - name: "1.31"
-            id: "1.31.14"
+            id: "1.33.12"
     rootDisk:
       - region: [common]
         type:

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
 ##### MC-INFRA-CONNECTOR #########################################################################################################################
 
   mc-infra-connector:
-    image: cloudbaristaorg/cb-spider:0.12.23
+    image: cloudbaristaorg/cb-spider:0.12.30
     pull_policy: missing
     container_name: mc-infra-connector
     restart: unless-stopped
@@ -56,7 +56,7 @@ services:
 ##### MC-INFRA-MANAGER #########################################################################################################################
 
   mc-infra-manager:
-    image: cloudbaristaorg/cb-tumblebug:0.12.12
+    image: cloudbaristaorg/cb-tumblebug:0.12.15
     container_name: mc-infra-manager
     restart: unless-stopped
     pull_policy: missing
@@ -227,7 +227,7 @@ services:
 
   # CB-MapUI is a Web-based test client (disable it for production use)
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.12.34
+    image: cloudbaristaorg/cb-mapui:0.12.39
     container_name: cb-mapui
     networks:
       - mc-infra-manager-network


### PR DESCRIPTION
## 내용
M-CMP를 위한 freeze 버전으로 Infra Connector 및 Manager를 업데이트 합니다.
- cb-tumblebug v0.12.15

## 연동 테스트(확인) 방법

CB-MapUI를 테스트 GUI로 인프라 리소스 프로비저닝 후,
- `infra-across-global` 템플릿 구동 (CSP 9종이 포함된, VM 클러스터) 
- `k8scluster-across` 템플릿 구동 (CSP 8종이 포함된, K8s 클러스터) 

<img width="395" height="265" alt="image" src="https://github.com/user-attachments/assets/db0db4e8-bed3-4b22-a615-574249a2f7fd" />


<img width="709" height="433" alt="image" src="https://github.com/user-attachments/assets/61a7c4df-0046-4343-9a2f-b99e8618ae8d" />

---

생성된 클러스터들을, MC-WebConsole 를 통해서 확인

<img width="866" height="677" alt="image" src="https://github.com/user-attachments/assets/5d1a3d60-8e1b-4d3a-973b-c95ce51ca403" />

<img width="859" height="429" alt="image" src="https://github.com/user-attachments/assets/6e83d2b9-a93f-484e-866f-8e530842963d" />
