### PR TITLE
chore: mc-workflow-manager-jenkins update version (0.5.2 -> 0.5.3 - pre Release)

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -860,7 +860,7 @@ services:
 
 
   mc-workflow-manager:
-    image: cloudbaristaorg/mc-workflow-manager:0.5.2
+    image: cloudbaristaorg/mc-workflow-manager:0.5.3
     container_name: mc-workflow-manager
     platform: linux/amd64
     networks:


### PR DESCRIPTION
chore: mc-workflow-manager-jenkins update version (0.5.2 -> 0.5.3 - pre Release)