### PR TITLE
sync api.yaml 

### DIFF
--- a/.github/workflows/no-ai-trace.yml
+++ b/.github/workflows/no-ai-trace.yml
@@ -1,0 +1,145 @@
+# ------------------------------------------------------------
+# Policy enforcement for open-source contributions: block AI direct commit signoff and co-authored-by attribution from being merged.
+#
+# In open-source contributions, the human author is expected to create commits and open pull requests. Under current open-source license frameworks (DCO, Sign-off, CLA, etc.) AI-attributed commits may have unclear implications. Following the community proposal from 2026-05-08, until the project policy is finalized, AI direct commit signoff and co-authored-by records are prohibited.
+#
+# Canonical source: https://github.com/MZC-CSC/cmig-workflow/blob/main/conf/workflow-templates/no-ai-trace.yml
+# Reference policy: https://github.com/MZC-CSC/cmig-workflow/blob/main/POLICY-AI-TRACE-GUARD.md
+# Local path in target repo: .github/workflows/no-ai-trace.yml
+# ------------------------------------------------------------
+
+name: AI Direct Commit Attribution Check
+
+on:
+  pull_request:
+    branches: [main, develop, master]
+  push:
+    branches: [main, develop, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  block-ai-attribution:
+    name: Block AI direct commit signoff and co-authored-by
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine commit range to scan
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "from=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+            echo "to=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE" ]; then
+              echo "from=${{ github.sha }}~1" >> $GITHUB_OUTPUT
+            else
+              echo "from=$BEFORE" >> $GITHUB_OUTPUT
+            fi
+            echo "to=${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Scan commits for AI direct attribution
+        id: scan
+        run: |
+          FROM="${{ steps.range.outputs.from }}"
+          TO="${{ steps.range.outputs.to }}"
+
+          # Patterns matched against commit message body and trailers
+          BODY_PATTERNS='Co-Authored-By:.*[Cc]laude|Co-Authored-By:.*[Aa]nthropic|Co-Authored-By:.*[Cc]opilot|Generated-By:.*[Cc]laude|Generated-By:.*[Cc]ode|Assisted-By|Co-Developed-By|noreply@anthropic\.com'
+
+          # Patterns matched against author and committer email
+          EMAIL_PATTERNS='@anthropic\.com|copilot-swe-agent'
+
+          FOUND=""
+          for sha in $(git rev-list "$FROM..$TO" 2>/dev/null); do
+            SUBJECT=$(git log -1 --pretty='%s' "$sha")
+            BODY=$(git log -1 --pretty='%B' "$sha")
+            AUTHOR_EMAIL=$(git log -1 --pretty='%ae' "$sha")
+            COMMITTER_EMAIL=$(git log -1 --pretty='%ce' "$sha")
+
+            BAD=""
+            HIT=$(echo "$BODY" | grep -iE "$BODY_PATTERNS" | head -3)
+            if [ -n "$HIT" ]; then
+              BAD="$BAD"$'\n'"  - body/trailer match:"$'\n'"$(echo "$HIT" | sed 's/^/      /')"
+            fi
+
+            for email in "$AUTHOR_EMAIL" "$COMMITTER_EMAIL"; do
+              if echo "$email" | grep -iqE "$EMAIL_PATTERNS"; then
+                BAD="$BAD"$'\n'"  - AI tool email match: $email"
+              fi
+            done
+
+            if [ -n "$BAD" ]; then
+              FOUND="$FOUND"$'\n\n'"### $sha"$'\n'"  subject: $SUBJECT$BAD"
+            fi
+          done
+
+          if [ -n "$FOUND" ]; then
+            {
+              echo "found=true"
+              echo "details<<EOF"
+              echo "$FOUND"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+
+            echo "::error::AI direct commit signoff or co-authored-by attribution detected. See logs and PR comment for details."
+            echo "$FOUND"
+            exit 1
+          fi
+
+          echo "found=false" >> $GITHUB_OUTPUT
+          echo "OK: no AI direct commit signoff or co-authored-by attribution found."
+
+      - name: Post failure comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const details = `${{ steps.scan.outputs.details }}`;
+            const body = [
+              '## AI Direct Commit Attribution Blocked',
+              '',
+              'This pull request cannot be merged because it contains commits with AI tool attribution (Claude, Anthropic, GitHub Copilot, etc.) in commit message trailers (for example `Co-Authored-By`, `Signed-off-by`, `Generated-By`) or in the author/committer email.',
+              '',
+              '### Why this is blocked',
+              '',
+              'In open-source contributions, the human author is expected to create commits and open pull requests. Under current open-source license frameworks (DCO, Sign-off, CLA, etc.) AI-attributed commits may have unclear implications. Following the community proposal from 2026-05-08, until the project policy is finalized, **AI direct commit signoff and co-authored-by records are prohibited** in this repository.',
+              '',
+              '<details><summary>Matched commits</summary>',
+              '',
+              '```',
+              details,
+              '```',
+              '',
+              '</details>',
+              '',
+              '### How to fix',
+              '',
+              'Most recent commit only - strip the attribution trailers:',
+              '```bash',
+              'git commit --amend --message="$(git log -1 --pretty=\'%s%n%n%b\' | grep -vE \'Co-Authored-By:|Generated-By:|Assisted-By:|Co-Developed-By:\')"',
+              'git push --force-with-lease',
+              '```',
+              '',
+              'Multiple commits - use interactive rebase:',
+              '```bash',
+              'git rebase -i HEAD~5',
+              '# Mark each commit as `reword` and remove the trailer lines in the editor',
+              'git push --force-with-lease',
+              '```',
+              '',
+              'The check will re-run automatically after the force-push, and the merge can proceed once the AI direct commit signoff and co-authored-by records are removed. Repository administrators may also enforce this check via Branch Protection rules.'
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -834,11 +834,11 @@ serviceActions:
       description: "해당 프레임워크 역할에 할당된 메뉴 리스트를 반환합니다."
     Deleteuser:
       method: delete
-      resourcePath: /api/user/id/{userid}
+      resourcePath: /api/users/id/{userId}
       description: "사용자를 삭제합니다."
     Updateuser:
       method: put
-      resourcePath: /api/user/id/{userid}
+      resourcePath: /api/users/id/{userId}
       description: "사용자 정보를 업데이트 합니다."
     Createworkspace:
       method: post
@@ -981,7 +981,7 @@ serviceActions:
       description: "특정 사용자의 워크스페이스 목록조회"
     Createuser:
       method: post
-      resourcePath: /api/user
+      resourcePath: /api/users
       description: "유저를 등록합니다."
     Deactiveuser:
       method: post
@@ -991,6 +991,222 @@ serviceActions:
       method: delete
       resourcePath: /api/projects/unassign/workspaces
       description: "Workspace에서 Project 할당 해제"
+    ListMcmpApisServices:
+      method: post
+      resourcePath: /api/mcmp-apis/list
+      description: "전체 프레임워크 서비스 목록 및 BaseURL 조회."
+    CreateFrameworkService:
+      method: post
+      resourcePath: /api/mcmp-apis
+      description: "프레임워크 서비스 신규 등록. body: {name, version, baseUrl, authType, isActive}"
+    UpdateFrameworkService:
+      method: put
+      resourcePath: /api/mcmp-apis/name/{serviceName}
+      description: "프레임워크 서비스 BaseURL 수정."
+    mciamCheckHealth:
+      method: get
+      resourcePath: /readyz
+      description: "mc-iam-manager 헬스체크."
+    assignPlatformRole:
+      method: post
+      resourcePath: /api/roles/assign/platform-role
+      description: "Platform Role 할당"
+    removePlatformRole:
+      method: delete
+      resourcePath: /api/roles/unassign/platform-role
+      description: "사용자에게서 Platform Role 제거"
+    listPlatformRoles:
+      method: post
+      resourcePath: /api/roles/platform-roles/list
+      description: "Platform Role 목록 조회"
+    AssignRoleToUser:
+      method: post
+      resourcePath: /api/roles/assign/platform-role
+      description: "사용자에게 플랫폼 역할을 할당합니다."
+    Signup:
+      method: post
+      resourcePath: /api/auth/signup
+      description: "신규 사용자 회원가입 (관리자 승인 후 로그인 가능)"
+    GetCspRoleById:
+      method: get
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: "CSP Role 단건 조회"
+    CreateCspRole:
+      method: post
+      resourcePath: /api/roles/csp
+      description: "CSP Role 생성"
+    DeleteCspRole:
+      method: delete
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: "CSP Role 삭제"
+    listCspPolicies:
+      method: post
+      resourcePath: /api/csp-policies/list
+      description: "CSP Policy 목록 조회"
+    GetCspPolicyById:
+      method: get
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 단건 조회"
+    CreateCspPolicy:
+      method: post
+      resourcePath: /api/csp-policies
+      description: "CSP Policy 생성"
+    UpdateCspPolicy:
+      method: put
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 수정"
+    DeleteCspPolicy:
+      method: delete
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 삭제"
+    GetPoliciesByRoleId:
+      method: get
+      resourcePath: /api/csp-policies/role/{roleId}
+      description: "CSP Role에 연결된 Policy 목록 조회"
+    AttachPolicyToRole:
+      method: post
+      resourcePath: /api/csp-policies/attach
+      description: "CSP Policy를 Role에 연결"
+    DetachPolicyFromRole:
+      method: post
+      resourcePath: /api/csp-policies/detach
+      description: "CSP Policy를 Role에서 해제"
+    SyncCspPolicies:
+      method: post
+      resourcePath: /api/csp-policies/sync
+      description: "CSP Policy 동기화"
+    Listmenustree:
+      method: post
+      resourcePath: /api/menus/menus-tree/list
+      description: "List all menus as tree structure (Admin only)"
+    Createmenu:
+      method: post
+      resourcePath: /api/menus
+      description: "Create a new menu"
+    Getmenubyid:
+      method: get
+      resourcePath: /api/menus/id/{menuId}
+      description: "Get menu details by ID"
+    Updatemenu:
+      method: put
+      resourcePath: /api/menus/id/{menuId}
+      description: "Update menu details"
+    Deletemenu:
+      method: delete
+      resourcePath: /api/menus/id/{menuId}
+      description: "Delete a menu"
+    UpdateUserStatus:
+      method: post
+      resourcePath: /api/users/id/{userId}/status
+      description: "사용자 승인/비활성화 (enabled true/false)"
+    ResetUserPassword:
+      method: put
+      resourcePath: /api/users/id/{userId}/password
+      description: "관리자가 사용자 비밀번호 재설정"
+    ChangeMyPassword:
+      method: put
+      resourcePath: /api/users/me/password
+      description: "사용자 본인 비밀번호 변경"
+    Createorganization:
+      method: post
+      resourcePath: /api/organizations
+      description: "그룹 생성"
+    Getorganizations:
+      method: get
+      resourcePath: /api/organizations
+      description: "그룹 목록/트리 조회 (query: tree=true면 중첩 구조)"
+    Getorganizationbyid:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 단건 조회 by ID"
+    Getorganizationbycode:
+      method: get
+      resourcePath: /api/organizations/code/{code}
+      description: "그룹 단건 조회 by code"
+    Updateorganization:
+      method: put
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 수정 (부모 변경 시 하위 코드 자동 재생성)"
+    Deleteorganization:
+      method: delete
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 삭제 (하위 그룹·소속 사용자 있으면 400)"
+    Getorganizationusers:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}/users
+      description: "그룹 소속 사용자 목록"
+    Assignuserorganizations:
+      method: post
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 그룹 할당 (다중)"
+    assignGroupUsers:
+      method: post
+      resourcePath: /api/groups/id/{groupId}/users
+      description: "그룹에 사용자 일괄 할당 (group 입장)"
+    Getuserorganizations:
+      method: get
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 소속 그룹 목록"
+    Removeuserorganization:
+      method: delete
+      resourcePath: /api/users/id/{userId}/organizations/{organizationId}
+      description: "사용자 그룹 제거"
+    listCspAccounts:
+      method: post
+      resourcePath: /api/csp-accounts/list
+      description: "CSP 계정 목록 조회 (필터: csp_type)"
+    createCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts
+      description: "CSP 계정 등록"
+    getCspAccountByID:
+      method: get
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 단건 조회 by ID"
+    updateCspAccount:
+      method: put
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 수정"
+    deleteCspAccount:
+      method: delete
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 삭제"
+    validateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/validate
+      description: "CSP 계정 자격증명 유효성 검증"
+    activateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/activate
+      description: "CSP 계정 활성화"
+    deactivateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/deactivate
+      description: "CSP 계정 비활성화"
+    GetProjectSyncDiff:
+      method: get
+      resourcePath: /api/setup/projects/sync-diff
+      description: "Infra NS ↔ IAM Project 동기화 차이 조회"
+    ApplyProjectSync:
+      method: post
+      resourcePath: /api/setup/projects/sync
+      description: "nsIds + workspaceId를 받아 Project 생성 + Workspace 할당"
+    listMenus:
+      method: post
+      resourcePath: /api/menus/list
+      description: "메뉴 목록 조회 (전체)"
+    InitialMenus:
+      method: post
+      resourcePath: /api/setup/initial-menus
+      description: "menu.yaml 기반 메뉴 일괄 재등록 (1_setup_auto.sh init_menu와 동일)"
+    SyncMcmpApis:
+      method: post
+      resourcePath: /api/setup/sync-mcmp-apis
+      description: "api.yaml 기반 mcmpApi 카탈로그 재동기화 (1_setup_auto.sh init_api_resources와 동일)"
+    syncProjects:
+      method: post
+      resourcePath: /api/setup/sync-projects
+      description: "mc-infra-manager의 namespace 목록을 가져와 project 테이블과 동기화"
 
   mc-infra-manager:
     Lookupspeclist:
@@ -1753,6 +1969,30 @@ serviceActions:
       method: post
       resourcePath: /ns/{nsId}/sharedResource
       description: "Create shared resources for MC-Infra"
+    GetCredentialHolderList:
+      method: get
+      resourcePath: /credentialHolder
+      description: "List all credential holders derived from registered connection configs."
+    GetAssetsSummary:
+      method: get
+      resourcePath: /assetsSummary
+      description: "Returns CSP-wise summary of specs and images in DB for a namespace."
+    PostMciSubGroupDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/mci/{mciId}/subGroupDynamic
+      description: "Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management"
+    RecommendSpec:
+      method: post
+      resourcePath: /recommendSpec
+      description: "Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
+    Postclusterremotecmd:
+      method: post
+      resourcePath: /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}
+      description: "Send a command to specified Cluster"
+    Postmcidynamicreview:
+      method: post
+      resourcePath: /ns/{nsId}/mciDynamicReview
+      description: "Create MCI Dynamically from common spec and image"
 
   mc-web-console:
     Anycontroller:
@@ -1795,6 +2035,10 @@ serviceActions:
       method: post
       resourcePath: /api/auth/validate
       description: webValidate
+    getSetupYamlCheck:
+      method: get
+      resourcePath: /api/admin/setup-yaml-check
+      description: "외부 raw YAML(menu/api) 도달성 확인 BFF endpoint. query: which=menu|api"
 
   mc-observability:
     Poststorage:
@@ -1809,7 +2053,7 @@ serviceActions:
       method: put
       resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage
       description: ""
-    Getminingdbtags":
+    Getminingdbtags:
       method: get
       resourcePath: /api/o11y/monitoring/miningdb/tag
       description: ""
@@ -2503,6 +2747,10 @@ serviceActions:
       method: get
       resourcePath: /api/v2/getWorkspaces
       description: "워크스페이스 목록을 조회합니다."
+    GetCostReadyz:
+      method: get
+      resourcePath: /api/costopti/be/readyz
+      description: "mc-cost-optimizer 헬스체크."
 
   mc-data-manager:
     GenerateWindows:

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -1713,6 +1713,10 @@ serviceActions:
       method: post
       resourcePath: /ns/{nsId}/mciDynamic
       description: "Create MCI Dynamically from common spec and image"
+    Postinfradynamicreview:
+      method: post
+      resourcePath: /ns/{nsId}/infraDynamicReview
+      description: "Review and validate Infra dynamic request comprehensively before actual provisioning"
     Inspectresourcesoverview:
       method: get
       resourcePath: /inspectResourcesOverview

--- a/conf/docker/api.yaml
+++ b/conf/docker/api.yaml
@@ -1825,6 +1825,10 @@ serviceActions:
       method: post
       resourcePath: /ns/{nsId}/mciDynamic
       description: "Create MCI Dynamically from common spec and image"
+    Postinfradynamicreview:
+      method: post
+      resourcePath: /ns/{nsId}/infraDynamicReview
+      description: "Review and validate Infra dynamic request comprehensively before actual provisioning"
     Inspectresourcesoverview:
       method: get
       resourcePath: /inspectResourcesOverview

--- a/conf/docker/api.yaml
+++ b/conf/docker/api.yaml
@@ -983,14 +983,6 @@ serviceActions:
       method: post
       resourcePath: /api/users
       description: "유저를 등록합니다."
-    ResetUserPassword:
-      method: put
-      resourcePath: /api/users/id/{userId}/password
-      description: "사용자 비밀번호를 초기화합니다."
-    AssignRoleToUser:
-      method: post
-      resourcePath: /api/roles/assign/platform-role
-      description: "사용자에게 플랫폼 역할을 할당합니다."
     Deactiveuser:
       method: post
       resourcePath: /api/user/deactive
@@ -999,110 +991,6 @@ serviceActions:
       method: delete
       resourcePath: /api/projects/unassign/workspaces
       description: "Workspace에서 Project 할당 해제"
-    # Group / Organization 관리
-    Getorganizations:
-      method: post
-      resourcePath: /api/organizations/list
-      description: "조직(그룹) 목록 조회"
-    listOrganizations:
-      method: get
-      resourcePath: /api/organizations
-      description: "조직(그룹) 전체 목록 조회"
-    createOrganization:
-      method: post
-      resourcePath: /api/organizations
-      description: "조직(그룹) 생성"
-    getOrganizationByID:
-      method: get
-      resourcePath: /api/organizations/id/{organizationId}
-      description: "조직(그룹) 단건 조회 by ID"
-    updateOrganization:
-      method: put
-      resourcePath: /api/organizations/id/{organizationId}
-      description: "조직(그룹) 수정"
-    deleteOrganization:
-      method: delete
-      resourcePath: /api/organizations/id/{organizationId}
-      description: "조직(그룹) 삭제"
-    getOrganizationUsers:
-      method: get
-      resourcePath: /api/organizations/id/{organizationId}/users
-      description: "조직(그룹) 소속 사용자 목록"
-    getOrganizationTree:
-      method: get
-      resourcePath: /api/organizations/tree
-      description: "조직 트리 조회"
-    assignUserOrganizations:
-      method: post
-      resourcePath: /api/users/{userId}/organizations
-      description: "사용자를 조직에 할당"
-    getUserOrganizations:
-      method: get
-      resourcePath: /api/users/{userId}/organizations
-      description: "사용자 소속 조직 목록"
-    removeUserOrganization:
-      method: delete
-      resourcePath: /api/users/{userId}/organizations/{organizationId}
-      description: "사용자 조직 할당 해제"
-    # Group Platform Role 관리
-    assignGroupPlatformRole:
-      method: post
-      resourcePath: /api/groups/id/{groupId}/platform-roles
-      description: "그룹에 플랫폼 역할 할당"
-    getGroupPlatformRoles:
-      method: get
-      resourcePath: /api/groups/id/{groupId}/platform-roles
-      description: "그룹의 플랫폼 역할 목록"
-    getAvailableGroupPlatformRoles:
-      method: get
-      resourcePath: /api/groups/id/{groupId}/platform-roles/available
-      description: "그룹에 할당 가능한 플랫폼 역할 목록"
-    removeGroupPlatformRole:
-      method: delete
-      resourcePath: /api/groups/id/{groupId}/platform-roles/{roleId}
-      description: "그룹 플랫폼 역할 할당 해제"
-    # Group Users 관리
-    assignGroupUsers:
-      method: post
-      resourcePath: /api/groups/id/{groupId}/users
-      description: "그룹에 사용자 일괄 할당"
-    removeGroupUser:
-      method: delete
-      resourcePath: /api/groups/id/{groupId}/users/{userId}
-      description: "그룹에서 사용자 제거"
-    assignUserGroups:
-      method: post
-      resourcePath: /api/users/id/{userId}/groups
-      description: "사용자를 그룹에 할당"
-    replaceUserGroups:
-      method: put
-      resourcePath: /api/users/id/{userId}/groups
-      description: "사용자 그룹 일괄 교체"
-    removeUserFromGroup:
-      method: delete
-      resourcePath: /api/users/id/{userId}/groups/{groupId}
-      description: "사용자를 그룹에서 제거"
-    # Group Workspace 관리
-    assignGroupWorkspace:
-      method: post
-      resourcePath: /api/groups/id/{groupId}/workspaces
-      description: "그룹을 워크스페이스에 매핑"
-    getGroupWorkspaces:
-      method: get
-      resourcePath: /api/groups/id/{groupId}/workspaces
-      description: "그룹의 워크스페이스 목록"
-    getAvailableGroupWorkspaces:
-      method: get
-      resourcePath: /api/groups/id/{groupId}/workspaces/available
-      description: "그룹에 할당 가능한 워크스페이스 목록"
-    updateGroupWorkspaceRole:
-      method: put
-      resourcePath: /api/groups/id/{groupId}/workspaces/{workspaceId}
-      description: "그룹-워크스페이스 역할 수정"
-    removeGroupWorkspaceRole:
-      method: delete
-      resourcePath: /api/groups/id/{groupId}/workspaces/{workspaceId}
-      description: "그룹-워크스페이스 매핑 해제"
 
   mc-infra-manager:
     Lookupspeclist:

--- a/conf/docker/api.yaml
+++ b/conf/docker/api.yaml
@@ -834,11 +834,11 @@ serviceActions:
       description: "해당 프레임워크 역할에 할당된 메뉴 리스트를 반환합니다."
     Deleteuser:
       method: delete
-      resourcePath: /api/user/id/{userid}
+      resourcePath: /api/users/id/{userId}
       description: "사용자를 삭제합니다."
     Updateuser:
       method: put
-      resourcePath: /api/user/id/{userid}
+      resourcePath: /api/users/id/{userId}
       description: "사용자 정보를 업데이트 합니다."
     Createworkspace:
       method: post
@@ -991,6 +991,222 @@ serviceActions:
       method: delete
       resourcePath: /api/projects/unassign/workspaces
       description: "Workspace에서 Project 할당 해제"
+    ListMcmpApisServices:
+      method: post
+      resourcePath: /api/mcmp-apis/list
+      description: "전체 프레임워크 서비스 목록 및 BaseURL 조회."
+    CreateFrameworkService:
+      method: post
+      resourcePath: /api/mcmp-apis
+      description: "프레임워크 서비스 신규 등록. body: {name, version, baseUrl, authType, isActive}"
+    UpdateFrameworkService:
+      method: put
+      resourcePath: /api/mcmp-apis/name/{serviceName}
+      description: "프레임워크 서비스 BaseURL 수정."
+    mciamCheckHealth:
+      method: get
+      resourcePath: /readyz
+      description: "mc-iam-manager 헬스체크."
+    assignPlatformRole:
+      method: post
+      resourcePath: /api/roles/assign/platform-role
+      description: "Platform Role 할당"
+    removePlatformRole:
+      method: delete
+      resourcePath: /api/roles/unassign/platform-role
+      description: "사용자에게서 Platform Role 제거"
+    listPlatformRoles:
+      method: post
+      resourcePath: /api/roles/platform-roles/list
+      description: "Platform Role 목록 조회"
+    AssignRoleToUser:
+      method: post
+      resourcePath: /api/roles/assign/platform-role
+      description: "사용자에게 플랫폼 역할을 할당합니다."
+    Signup:
+      method: post
+      resourcePath: /api/auth/signup
+      description: "신규 사용자 회원가입 (관리자 승인 후 로그인 가능)"
+    GetCspRoleById:
+      method: get
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: "CSP Role 단건 조회"
+    CreateCspRole:
+      method: post
+      resourcePath: /api/roles/csp
+      description: "CSP Role 생성"
+    DeleteCspRole:
+      method: delete
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: "CSP Role 삭제"
+    listCspPolicies:
+      method: post
+      resourcePath: /api/csp-policies/list
+      description: "CSP Policy 목록 조회"
+    GetCspPolicyById:
+      method: get
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 단건 조회"
+    CreateCspPolicy:
+      method: post
+      resourcePath: /api/csp-policies
+      description: "CSP Policy 생성"
+    UpdateCspPolicy:
+      method: put
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 수정"
+    DeleteCspPolicy:
+      method: delete
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 삭제"
+    GetPoliciesByRoleId:
+      method: get
+      resourcePath: /api/csp-policies/role/{roleId}
+      description: "CSP Role에 연결된 Policy 목록 조회"
+    AttachPolicyToRole:
+      method: post
+      resourcePath: /api/csp-policies/attach
+      description: "CSP Policy를 Role에 연결"
+    DetachPolicyFromRole:
+      method: post
+      resourcePath: /api/csp-policies/detach
+      description: "CSP Policy를 Role에서 해제"
+    SyncCspPolicies:
+      method: post
+      resourcePath: /api/csp-policies/sync
+      description: "CSP Policy 동기화"
+    Listmenustree:
+      method: post
+      resourcePath: /api/menus/menus-tree/list
+      description: "List all menus as tree structure (Admin only)"
+    Createmenu:
+      method: post
+      resourcePath: /api/menus
+      description: "Create a new menu"
+    Getmenubyid:
+      method: get
+      resourcePath: /api/menus/id/{menuId}
+      description: "Get menu details by ID"
+    Updatemenu:
+      method: put
+      resourcePath: /api/menus/id/{menuId}
+      description: "Update menu details"
+    Deletemenu:
+      method: delete
+      resourcePath: /api/menus/id/{menuId}
+      description: "Delete a menu"
+    UpdateUserStatus:
+      method: post
+      resourcePath: /api/users/id/{userId}/status
+      description: "사용자 승인/비활성화 (enabled true/false)"
+    ResetUserPassword:
+      method: put
+      resourcePath: /api/users/id/{userId}/password
+      description: "관리자가 사용자 비밀번호 재설정"
+    ChangeMyPassword:
+      method: put
+      resourcePath: /api/users/me/password
+      description: "사용자 본인 비밀번호 변경"
+    Createorganization:
+      method: post
+      resourcePath: /api/organizations
+      description: "그룹 생성"
+    Getorganizations:
+      method: get
+      resourcePath: /api/organizations
+      description: "그룹 목록/트리 조회 (query: tree=true면 중첩 구조)"
+    Getorganizationbyid:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 단건 조회 by ID"
+    Getorganizationbycode:
+      method: get
+      resourcePath: /api/organizations/code/{code}
+      description: "그룹 단건 조회 by code"
+    Updateorganization:
+      method: put
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 수정 (부모 변경 시 하위 코드 자동 재생성)"
+    Deleteorganization:
+      method: delete
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 삭제 (하위 그룹·소속 사용자 있으면 400)"
+    Getorganizationusers:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}/users
+      description: "그룹 소속 사용자 목록"
+    Assignuserorganizations:
+      method: post
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 그룹 할당 (다중)"
+    assignGroupUsers:
+      method: post
+      resourcePath: /api/groups/id/{groupId}/users
+      description: "그룹에 사용자 일괄 할당 (group 입장)"
+    Getuserorganizations:
+      method: get
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 소속 그룹 목록"
+    Removeuserorganization:
+      method: delete
+      resourcePath: /api/users/id/{userId}/organizations/{organizationId}
+      description: "사용자 그룹 제거"
+    listCspAccounts:
+      method: post
+      resourcePath: /api/csp-accounts/list
+      description: "CSP 계정 목록 조회 (필터: csp_type)"
+    createCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts
+      description: "CSP 계정 등록"
+    getCspAccountByID:
+      method: get
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 단건 조회 by ID"
+    updateCspAccount:
+      method: put
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 수정"
+    deleteCspAccount:
+      method: delete
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 삭제"
+    validateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/validate
+      description: "CSP 계정 자격증명 유효성 검증"
+    activateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/activate
+      description: "CSP 계정 활성화"
+    deactivateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/deactivate
+      description: "CSP 계정 비활성화"
+    GetProjectSyncDiff:
+      method: get
+      resourcePath: /api/setup/projects/sync-diff
+      description: "Infra NS ↔ IAM Project 동기화 차이 조회"
+    ApplyProjectSync:
+      method: post
+      resourcePath: /api/setup/projects/sync
+      description: "nsIds + workspaceId를 받아 Project 생성 + Workspace 할당"
+    listMenus:
+      method: post
+      resourcePath: /api/menus/list
+      description: "메뉴 목록 조회 (전체)"
+    InitialMenus:
+      method: post
+      resourcePath: /api/setup/initial-menus
+      description: "menu.yaml 기반 메뉴 일괄 재등록 (1_setup_auto.sh init_menu와 동일)"
+    SyncMcmpApis:
+      method: post
+      resourcePath: /api/setup/sync-mcmp-apis
+      description: "api.yaml 기반 mcmpApi 카탈로그 재동기화 (1_setup_auto.sh init_api_resources와 동일)"
+    syncProjects:
+      method: post
+      resourcePath: /api/setup/sync-projects
+      description: "mc-infra-manager의 namespace 목록을 가져와 project 테이블과 동기화"
 
   mc-infra-manager:
     Lookupspeclist:
@@ -1753,6 +1969,30 @@ serviceActions:
       method: post
       resourcePath: /ns/{nsId}/sharedResource
       description: "Create shared resources for MC-Infra"
+    GetCredentialHolderList:
+      method: get
+      resourcePath: /credentialHolder
+      description: "List all credential holders derived from registered connection configs."
+    GetAssetsSummary:
+      method: get
+      resourcePath: /assetsSummary
+      description: "Returns CSP-wise summary of specs and images in DB for a namespace."
+    PostMciSubGroupDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/mci/{mciId}/subGroupDynamic
+      description: "Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management"
+    RecommendSpec:
+      method: post
+      resourcePath: /recommendSpec
+      description: "Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
+    Postclusterremotecmd:
+      method: post
+      resourcePath: /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}
+      description: "Send a command to specified Cluster"
+    Postmcidynamicreview:
+      method: post
+      resourcePath: /ns/{nsId}/mciDynamicReview
+      description: "Create MCI Dynamically from common spec and image"
 
   mc-web-console:
     Anycontroller:
@@ -1795,6 +2035,10 @@ serviceActions:
       method: post
       resourcePath: /api/auth/validate
       description: webValidate
+    getSetupYamlCheck:
+      method: get
+      resourcePath: /api/admin/setup-yaml-check
+      description: "외부 raw YAML(menu/api) 도달성 확인 BFF endpoint. query: which=menu|api"
 
   mc-observability:
     Poststorage:
@@ -1809,7 +2053,7 @@ serviceActions:
       method: put
       resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage
       description: ""
-    Getminingdbtags":
+    Getminingdbtags:
       method: get
       resourcePath: /api/o11y/monitoring/miningdb/tag
       description: ""
@@ -2503,6 +2747,10 @@ serviceActions:
       method: get
       resourcePath: /api/v2/getWorkspaces
       description: "워크스페이스 목록을 조회합니다."
+    GetCostReadyz:
+      method: get
+      resourcePath: /api/costopti/be/readyz
+      description: "mc-cost-optimizer 헬스체크."
 
   mc-data-manager:
     GenerateWindows:

--- a/conf/docker/conf/mc-web-console/api/conf/api.yaml
+++ b/conf/docker/conf/mc-web-console/api/conf/api.yaml
@@ -1981,6 +1981,18 @@ serviceActions:
       method: post
       resourcePath: /ns/{nsId}/mciDynamicReview
       description: "Create MCI Dynamically from common spec and image"
+    Postinfradynamicreview:
+      method: post
+      resourcePath: /ns/{nsId}/infraDynamicReview
+      description: "Review and validate Infra dynamic request comprehensively before actual provisioning"
+    Postmcivmdynamic:
+      method: post
+      resourcePath: /ns/{nsId}/mci/{mciId}/vmDynamic
+      description: "Create VM Dynamically and add it to MCI"
+    Recommendvm:
+      method: post
+      resourcePath: /mciRecommendVm
+      description: "Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
 
   mc-web-console:
     getSetupYamlCheck:


### PR DESCRIPTION
sync api.yaml 
- Fill missing serviceActions across conf/api.yaml, conf/docker/api.yaml,
  and mc-web-console api.yaml (union, excluding mc-observability)
- Add PostInfraDynamicReview to all three
- Unify user endpoints to /api/users and /api/users/id/{userId}
- Fix typo key Getminingdbtags": -> Getminingdbtags:
