### PR TITLE
sync(api): update serviceActions from mc-web-console conf/api.yaml

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -85,139 +85,139 @@ serviceActions:
     Remove-Nodegroup:
       method: delete
       resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}
-      description: "Remove an existing Node Group from a Cluster."
+      description: Remove an existing Node Group from a Cluster.
     List-Connection-Configs:
       method: get
       resourcePath: /connectionconfig
-      description: "Retrieve a list of registered Connection Configs."
+      description: Retrieve a list of registered Connection Configs.
     Create-Connection-Config:
       method: post
       resourcePath: /connectionconfig
-      description: "Create a new Connection Config. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-cloud-connection-configuration-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+      description: Create a new Connection Config. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-cloud-connection-configuration-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]
     Count-Subnets-By-Connection:
       method: get
       resourcePath: /countsubnet/{ConnectionName}
-      description: "Get the total number of Subnets for a specific connection."
+      description: Get the total number of Subnets for a specific connection.
     Count-Vpcs-By-Connection:
       method: get
       resourcePath: /countvpc/{ConnectionName}
-      description: "Get the total number of VPCs for a specific connection."
+      description: Get the total number of VPCs for a specific connection.
     Upload-Cloud-Driver:
       method: post
       resourcePath: /driver/upload
-      description: "Upload a Cloud Driver library file."
+      description: Upload a Cloud Driver library file.
     Health-Check-Readyz:
       method: get
       resourcePath: /readyz
-      description: "Checks the health of CB-Spider service and its dependencies via /readyz endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+      description: Checks the health of CB-Spider service and its dependencies via /readyz endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]
     Unregister-Subnet:
       method: delete
       resourcePath: /regsubnet/{Name}
-      description: "Unregister a Subnet from a specified VPC."
+      description: Unregister a Subnet from a specified VPC.
     Get-Vm-Status:
       method: get
       resourcePath: /vmstatus/{Name}
-      description: "Retrieve the status of a specific Virtual Machine (VM)."
+      description: Retrieve the status of a specific Virtual Machine (VM).
     List-All-Vpc:
       method: get
       resourcePath: /allvpc
-      description: "Retrieve a comprehensive list of all Virtual Private Clouds (VPCs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Virtual Private Clouds (VPCs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Any-Call:
       method: post
       resourcePath: /anycall
-      description: "Execute a custom function (FID) with key-value parameters through AnyCall. 🕷️ [[Development Guide](https://github.com/cloud-barista/cb-spider/wiki/AnyCall-API-Extension-Guide)]"
+      description: Execute a custom function (FID) with key-value parameters through AnyCall. 🕷️ [[Development Guide](https://github.com/cloud-barista/cb-spider/wiki/AnyCall-API-Extension-Guide)]
     Get-Credential:
       method: get
       resourcePath: /credential/{CredentialName}
-      description: "Retrieve details of a specific Credential."
+      description: Retrieve details of a specific Credential.
     Unregister-Credential:
       method: delete
       resourcePath: /credential/{CredentialName}
-      description: "Unregister a specific Credential."
+      description: Unregister a specific Credential.
     Get-Disk:
       method: get
       resourcePath: /disk/{Name}
-      description: "Retrieve details of a specific Disk."
+      description: Retrieve details of a specific Disk.
     Delete-Disk:
       method: delete
       resourcePath: /disk/{Name}
-      description: "Delete a specified Disk."
+      description: Delete a specified Disk.
     List-Product-Family:
       method: get
       resourcePath: /productfamily/{RegionName}
-      description: "Retrieve a list of Product Families associated with a specific connection and region. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Price-Info-and-Cloud-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/RestAPI-Multi%E2%80%90Cloud-Price-Information-Guide)]"
+      description: Retrieve a list of Product Families associated with a specific connection and region. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Price-Info-and-Cloud-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/RestAPI-Multi%E2%80%90Cloud-Price-Information-Guide)]
     Get-Region:
       method: get
       resourcePath: /region/{RegionName}
-      description: "Retrieve details of a specific Region."
+      description: Retrieve details of a specific Region.
     Unregister-Region:
       method: delete
       resourcePath: /region/{RegionName}
-      description: "Unregister a specific Region."
+      description: Unregister a specific Region.
     Remove-Csp-Subnet:
       method: delete
       resourcePath: /vpc/{VPCName}/cspsubnet/{Id}
-      description: "Remove an existing CSP Subnet from a VPC."
+      description: Remove an existing CSP Subnet from a VPC.
     List-All-Vm:
       method: get
       resourcePath: /allvm
-      description: "Retrieve a comprehensive list of all Virtual Machines (VMs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Virtual Machines (VMs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Get-Myimage:
       method: get
       resourcePath: /myimage/{Name}
-      description: "Retrieve details of a specific MyImage."
+      description: Retrieve details of a specific MyImage.
     Delete-Myimage:
       method: delete
       resourcePath: /myimage/{Name}
-      description: "Delete a specified MyImage."
+      description: Delete a specified MyImage.
     Count-All-Clusters:
       method: get
       resourcePath: /countcluster
-      description: "Get the total number of Clusters across all connections."
+      description: Get the total number of Clusters across all connections.
     Count-All-Subnets:
       method: get
       resourcePath: /countsubnet
-      description: "Get the total number of Subnets across all connections."
+      description: Get the total number of Subnets across all connections.
     Get-Image:
       method: get
       resourcePath: /vmimage/{Name}
-      description: "Retrieve details of a specific Public Image. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
+      description: Retrieve details of a specific Public Image. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]
     Remove-Subnet:
       method: delete
       resourcePath: /vpc/{VPCName}/subnet/{SubnetName}
-      description: "Remove an existing Subnet from a VPC."
+      description: Remove an existing Subnet from a VPC.
     List-All-Cluster:
       method: get
       resourcePath: /allcluster
-      description: "Retrieve a comprehensive list of all Clusters associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Clusters associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Upgrade-Cluster:
       method: put
       resourcePath: /cluster/{Name}/upgrade
-      description: "Upgrade a Cluster to a specified version."
+      description: Upgrade a Cluster to a specified version.
     Count-Clusters-By-Connection:
       method: get
       resourcePath: /countcluster/{ConnectionName}
-      description: "Get the total number of Clusters for a specific connection."
+      description: Get the total number of Clusters for a specific connection.
     Count-All-Nlbs:
       method: get
       resourcePath: /countnlb
-      description: "Get the total number of Network Load Balancers (NLBs) across all connections."
+      description: Get the total number of Network Load Balancers (NLBs) across all connections.
     Attach-Disk:
       method: put
       resourcePath: /disk/{Name}/attach
-      description: "Attach an existing Disk to a VM."
+      description: Attach an existing Disk to a VM.
     Get-Cluster-Owner-Vpc:
       method: post
       resourcePath: /getclusterowner
-      description: "Retrieve the owner VPC of a specified Cluster."
+      description: Retrieve the owner VPC of a specified Cluster.
     Count-Vms-By-Connection:
       method: get
       resourcePath: /countvm/{ConnectionName}
-      description: "Get the total number of Virtual Machines (VMs) for a specific connection."
+      description: Get the total number of Virtual Machines (VMs) for a specific connection.
     Get-Region-Zone-Preconfig:
       method: get
       resourcePath: /preconfig/regionzone/{Name}
-      description: "Retrieve details of a specific pre-configured Region Zone based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+      description: Retrieve details of a specific pre-configured Region Zone based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]
     Get-Price-Info:
       method: post
       resourcePath: /priceinfo/{ProductFamily}/{RegionName}
@@ -225,772 +225,460 @@ serviceActions:
     Register-Vm:
       method: post
       resourcePath: /regvm
-      description: "Register a new Virtual Machine (VM) with the specified name and CSP ID."
+      description: Register a new Virtual Machine (VM) with the specified name and CSP ID.
     List-Key:
       method: get
       resourcePath: /keypair
-      description: "Retrieve a list of KeyPairs associated with a specific connection."
+      description: Retrieve a list of KeyPairs associated with a specific connection.
     Create-Key:
       method: post
       resourcePath: /keypair
-      description: "Create a new KeyPair with the specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#5-vm-keypair-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+      description: Create a new KeyPair with the specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#5-vm-keypair-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]
     Unregister-Vm:
       method: delete
       resourcePath: /regvm/{Name}
-      description: "Unregister a Virtual Machine (VM) with the specified name."
+      description: Unregister a Virtual Machine (VM) with the specified name.
     List-All-Securitygroups:
       method: get
       resourcePath: /allsecuritygroup
-      description: "Retrieve a comprehensive list of all Security Groups associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Security Groups associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Delete-Csp-Securitygroup:
       method: delete
       resourcePath: /cspsecuritygroup/{Id}
-      description: "Delete a specified CSP Security Group."
+      description: Delete a specified CSP Security Group.
     List-Preconfigured-Original-Org-Region:
       method: get
       resourcePath: /preconfig/orgregion
-      description: "Retrieve a list of pre-configured Original Regions based on driver and credential names. <br> The response structure may vary depending on the request DriverName and CredentialName."
+      description: Retrieve a list of pre-configured Original Regions based on driver and credential names. <br> The response structure may vary depending on the request DriverName and CredentialName.
     Unregister-Vpc:
       method: delete
       resourcePath: /regvpc/{Name}
-      description: "Unregister a VPC with the specified name."
+      description: Unregister a VPC with the specified name.
     List-Org-Vm-Spec:
       method: get
       resourcePath: /vmorgspec
-      description: "Retrieve a list of Original VM Specs associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName."
+      description: Retrieve a list of Original VM Specs associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName.
     Get-Org-Vm-Spec:
       method: get
       resourcePath: /vmorgspec/{Name}
-      description: "Retrieve details of a specific Original VM Spec."
+      description: Retrieve details of a specific Original VM Spec.
     List-All-Key:
       method: get
       resourcePath: /allkeypair
-      description: "Retrieve a comprehensive list of all KeyPairs associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all KeyPairs associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Get-Region-Zone:
       method: get
       resourcePath: /regionzone/{Name}
-      description: "Retrieve details of a specific Region Zone. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+      description: Retrieve details of a specific Region Zone. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]
     Add-Rules-Securitygroup:
       method: post
       resourcePath: /securitygroup/{SGName}/rules
-      description: "Add new rules to a Security Group."
+      description: Add new rules to a Security Group.
     Remove-Rules-Securitygroup:
       method: delete
       resourcePath: /securitygroup/{SGName}/rules
-      description: "Remove existing rules from a Security Group."
+      description: Remove existing rules from a Security Group.
     Delete-Csp-Myimage:
       method: delete
       resourcePath: /cspmyimage/{Id}
-      description: "Delete a specified CSP MyImage."
+      description: Delete a specified CSP MyImage.
     Unregister-Myimage:
       method: delete
       resourcePath: /regmyimage/{Name}
-      description: "Unregister a MyImage with the specified name."
+      description: Unregister a MyImage with the specified name.
     Register-Nlb:
       method: post
       resourcePath: /regnlb
-      description: "Register a new Network Load Balancer (NLB) with the specified name and CSP ID."
+      description: Register a new Network Load Balancer (NLB) with the specified name and CSP ID.
     Get-Securitygroup:
       method: get
       resourcePath: /securitygroup/{Name}
-      description: "Retrieve details of a specific Security Group."
+      description: Retrieve details of a specific Security Group.
     Delete-Securitygroup:
       method: delete
       resourcePath: /securitygroup/{Name}
-      description: "Delete a specified Security Group."
+      description: Delete a specified Security Group.
     Terminate-Vm:
       method: delete
       resourcePath: /vm/{Name}
-      description: "Terminate a specified Virtual Machine (VM)."
+      description: Terminate a specified Virtual Machine (VM).
     Get-Vm:
       method: get
       resourcePath: /vm/{Name}
-      description: "Retrieve details of a specific Virtual Machine (VM)."
+      description: Retrieve details of a specific Virtual Machine (VM).
     Register-Subnet:
       method: post
       resourcePath: /regsubnet
-      description: "Register a new Subnet within a specified VPC."
+      description: Register a new Subnet within a specified VPC.
     Add-Subnet:
       method: post
       resourcePath: /vpc/{VPCName}/subnet
-      description: "Add a new Subnet to an existing VPC."
+      description: Add a new Subnet to an existing VPC.
     List-Cloudos:
       method: get
       resourcePath: /cloudos
-      description: "Retrieve a list of supported Cloud OS."
+      description: Retrieve a list of supported Cloud OS.
     Count-All-Keys:
       method: get
       resourcePath: /countkeypair
-      description: "Get the total number of KeyPairs across all connections."
+      description: Get the total number of KeyPairs across all connections.
     Count-Securitygroups-By-Connection:
       method: get
       resourcePath: /countsecuritygroup/{ConnectionName}
-      description: "Get the total number of Security Groups for a specific connection."
+      description: Get the total number of Security Groups for a specific connection.
     Health-Check-Ping:
       method: get
       resourcePath: /ping
-      description: "Checks the health of CB-Spider service and its dependencies via /ping endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+      description: Checks the health of CB-Spider service and its dependencies via /ping endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]
     List-Vm-Status:
       method: get
       resourcePath: /vmstatus
-      description: "Retrieve a list of statuses for Virtual Machines (VMs) associated with a specific connection."
+      description: Retrieve a list of statuses for Virtual Machines (VMs) associated with a specific connection.
     Count-Connections-By-Provider:
       method: get
       resourcePath: /countconnectionconfig/{ProviderName}
-      description: "Get the total number of connections for a specific provider."
+      description: Get the total number of connections for a specific provider.
     Delete-Csp-Cluster:
       method: delete
       resourcePath: /cspcluster/{Id}
-      description: "Delete a specified CSP Cluster."
+      description: Delete a specified CSP Cluster.
     Unregister-Cluster:
       method: delete
       resourcePath: /regcluster/{Name}
-      description: "Unregister a Cluster with the specified name."
+      description: Unregister a Cluster with the specified name.
     Register-Myimage:
       method: post
       resourcePath: /regmyimage
-      description: "Register a new MyImage with the specified name and CSP ID."
+      description: Register a new MyImage with the specified name and CSP ID.
     Unregister-Securitygroup:
       method: delete
       resourcePath: /regsecuritygroup/{Name}
-      description: "Unregister a Security Group with the specified name."
+      description: Unregister a Security Group with the specified name.
     Get-Vm-Spec:
       method: get
       resourcePath: /vmspec/{Name}
-      description: "Retrieve details of a specific VM spec. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
+      description: Retrieve details of a specific VM spec. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]
     List-Cluster:
       method: get
       resourcePath: /cluster
-      description: "Retrieve a list of Clusters associated with a specific connection."
+      description: Retrieve a list of Clusters associated with a specific connection.
     Create-Cluster:
       method: post
       resourcePath: /cluster
-      description: "Create a new Cluster with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Provider-Managed-Kubernetes-and-Driver-API)] <br> * NodeGroupList is optional, depends on CSP type: <br> &nbsp;- Type-I (e.g., Tencent, Alibaba): requires separate Node Group addition after Cluster creation. <br> &nbsp;- Type-II (e.g., Azure, NHN): mandates at least one Node Group during initial Cluster creation."
+      description: 'Create a new Cluster with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Provider-Managed-Kubernetes-and-Driver-API)] <br> * NodeGroupList is optional, depends on CSP type: <br> &nbsp;- Type-I (e.g., Tencent, Alibaba): requires separate Node Group addition after Cluster creation. <br> &nbsp;- Type-II (e.g., Azure, NHN): mandates at least one Node Group during initial Cluster creation.'
     Count-All-Myimages:
       method: get
       resourcePath: /countmyimage
-      description: "Get the total number of MyImages across all connections."
+      description: Get the total number of MyImages across all connections.
     Detach-Disk:
       method: put
       resourcePath: /disk/{Name}/detach
-      description: "Detach an existing Disk from a VM."
+      description: Detach an existing Disk from a VM.
     List-Cloud-Drivers:
       method: get
       resourcePath: /driver
-      description: "Retrieve a list of registered Cloud Drivers."
+      description: Retrieve a list of registered Cloud Drivers.
     Register-Cloud-Driver:
       method: post
       resourcePath: /driver
-      description: "Register a new Cloud Driver. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#1-cloud-driver-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+      description: Register a new Cloud Driver. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#1-cloud-driver-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]
     List-Nlb:
       method: get
       resourcePath: /nlb
-      description: "Retrieve a list of Network Load Balancers (NLBs) associated with a specific connection."
+      description: Retrieve a list of Network Load Balancers (NLBs) associated with a specific connection.
     Create-Nlb:
       method: post
       resourcePath: /nlb
-      description: "Create a new Network Load Balancer (NLB) with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Network-Load-Balancer-and-Driver-API)]"
+      description: Create a new Network Load Balancer (NLB) with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Network-Load-Balancer-and-Driver-API)]
     List-Org-Zone:
       method: get
       resourcePath: /orgzone
-      description: "Retrieve a list of Original Zones associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName."
+      description: Retrieve a list of Original Zones associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName.
     Health-Check-Healthcheck:
       method: get
       resourcePath: /healthcheck
-      description: "Checks the health of CB-Spider service and its dependencies via /healthcheck endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+      description: Checks the health of CB-Spider service and its dependencies via /healthcheck endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]
     Delete-Key:
       method: delete
       resourcePath: /keypair/{Name}
-      description: "Delete a specified KeyPair."
+      description: Delete a specified KeyPair.
     Get-Key:
       method: get
       resourcePath: /keypair/{Name}
-      description: "Retrieve details of a specific KeyPair."
+      description: Retrieve details of a specific KeyPair.
     List-Image:
       method: get
       resourcePath: /vmimage
-      description: "Retrieve a list of Public Images associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
+      description: Retrieve a list of Public Images associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]
     Get-Cluster:
       method: get
       resourcePath: /cluster/{Name}
-      description: "Retrieve details of a specific Cluster."
+      description: Retrieve details of a specific Cluster.
     Delete-Cluster:
       method: delete
       resourcePath: /cluster/{Name}
-      description: "Delete a specified Cluster."
+      description: Delete a specified Cluster.
     Get-Csp-Vm:
       method: get
       resourcePath: /cspvm/{Id}
-      description: "Retrieve details of a specific CSP Virtual Machine (VM)."
+      description: Retrieve details of a specific CSP Virtual Machine (VM).
     Terminate-Csp-Vm:
       method: delete
       resourcePath: /cspvm/{Id}
-      description: "Terminate a specified CSP Virtual Machine (VM)."
+      description: Terminate a specified CSP Virtual Machine (VM).
     Health-Check-Health:
       method: get
       resourcePath: /health
-      description: "Checks the health of CB-Spider service and its dependencies via /health endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+      description: Checks the health of CB-Spider service and its dependencies via /health endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]
     Register-Vpc:
       method: post
       resourcePath: /regvpc
-      description: "Register a new Virtual Private Cloud (VPC) with the specified name and CSP ID."
+      description: Register a new Virtual Private Cloud (VPC) with the specified name and CSP ID.
     Unregister-Nlb:
       method: delete
       resourcePath: /regnlb/{Name}
-      description: "Unregister a Network Load Balancer (NLB) with the specified name."
+      description: Unregister a Network Load Balancer (NLB) with the specified name.
     Get-Sg-Owner-Vpc:
       method: post
       resourcePath: /getsecuritygroupowner
-      description: "Retrieve the owner VPC of a specified Security Group."
+      description: Retrieve the owner VPC of a specified Security Group.
     Create-Vpc:
       method: post
       resourcePath: /vpc
-      description: "Create a new Virtual Private Cloud (VPC) with specified subnet configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-vpcsubnet-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+      description: Create a new Virtual Private Cloud (VPC) with specified subnet configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-vpcsubnet-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]
     List-Vpc:
       method: get
       resourcePath: /vpc
-      description: "Retrieve a list of Virtual Private Clouds (VPCs) associated with a specific connection."
+      description: Retrieve a list of Virtual Private Clouds (VPCs) associated with a specific connection.
     Control-Vm:
       method: put
       resourcePath: /controlvm/{Name}
-      description: "Control the state of a Virtual Machine (VM) such as suspend, resume, or reboot."
+      description: Control the state of a Virtual Machine (VM) such as suspend, resume, or reboot.
     List-All-Myimage:
       method: get
       resourcePath: /allmyimage
-      description: "Retrieve a comprehensive list of all MyImages associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all MyImages associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Count-Disks-By-Connection:
       method: get
       resourcePath: /countdisk/{ConnectionName}
-      description: "Get the total number of Disks for a specific connection."
+      description: Get the total number of Disks for a specific connection.
     List-Credentials:
       method: get
       resourcePath: /credential
-      description: "Retrieve a list of registered Credentials."
+      description: Retrieve a list of registered Credentials.
     Register-Credential:
       method: post
       resourcePath: /credential
-      description: "Register a new Credential. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-cloud-credential-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+      description: Register a new Credential. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-cloud-credential-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]
     Delete-Csp-Disk:
       method: delete
       resourcePath: /cspdisk/{Id}
-      description: "Delete a specified CSP Disk."
+      description: Delete a specified CSP Disk.
     Register-Key:
       method: post
       resourcePath: /regkeypair
-      description: "Register a new KeyPair with the specified name and CSP ID."
+      description: Register a new KeyPair with the specified name and CSP ID.
     List-All-Nlb:
       method: get
       resourcePath: /allnlb
-      description: "Retrieve a comprehensive list of all Network Load Balancers (NLBs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Network Load Balancers (NLBs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Set-Nodegroup-Autoscaling:
       method: put
       resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/onautoscaling
-      description: "Enable or disable auto scaling for a Node Group in a Cluster."
+      description: Enable or disable auto scaling for a Node Group in a Cluster.
     List-Vm-Spec:
       method: get
       resourcePath: /vmspec
-      description: "Retrieve a list of VM specs associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
+      description: Retrieve a list of VM specs associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]
     Count-All-Disks:
       method: get
       resourcePath: /countdisk
-      description: "Get the total number of Disks across all connections."
+      description: Get the total number of Disks across all connections.
     Register-Cluster:
       method: post
       resourcePath: /regcluster
-      description: "Register a new Cluster with the specified VPC and CSP ID."
+      description: Register a new Cluster with the specified VPC and CSP ID.
     Register-Securitygroup:
       method: post
       resourcePath: /regsecuritygroup
-      description: "Register a new Security Group with the specified name and CSP ID."
+      description: Register a new Security Group with the specified name and CSP ID.
     Get-Vpc:
       method: get
       resourcePath: /vpc/{Name}
-      description: "Retrieve details of a specific Virtual Private Cloud (VPC)."
+      description: Retrieve details of a specific Virtual Private Cloud (VPC).
     Delete-Vpc:
       method: delete
       resourcePath: /vpc/{Name}
-      description: "Delete a specified Virtual Private Cloud (VPC)."
+      description: Delete a specified Virtual Private Cloud (VPC).
     Get-Connection-Config:
       method: get
       resourcePath: /connectionconfig/{ConfigName}
-      description: "Retrieve details of a specific Connection Config."
+      description: Retrieve details of a specific Connection Config.
     Delete-Connection-Config:
       method: delete
       resourcePath: /connectionconfig/{ConfigName}
-      description: "Delete a specific Connection Config."
+      description: Delete a specific Connection Config.
     Get-Cloud-Driver:
       method: get
       resourcePath: /driver/{DriverName}
-      description: "Retrieve details of a specific Cloud Driver."
+      description: Retrieve details of a specific Cloud Driver.
     Unregister-Cloud-Driver:
       method: delete
       resourcePath: /driver/{DriverName}
-      description: "Unregister a specific Cloud Driver."
+      description: Unregister a specific Cloud Driver.
     Count-Nlbs-By-Connection:
       method: get
       resourcePath: /countnlb/{ConnectionName}
-      description: "Get the total number of Network Load Balancers (NLBs) for a specific connection."
+      description: Get the total number of Network Load Balancers (NLBs) for a specific connection.
     Delete-Nlb:
       method: delete
       resourcePath: /nlb/{Name}
-      description: "Delete a specified Network Load Balancer (NLB)."
+      description: Delete a specified Network Load Balancer (NLB).
     Get-Nlb:
       method: get
       resourcePath: /nlb/{Name}
-      description: "Retrieve details of a specific Network Load Balancer (NLB)."
+      description: Retrieve details of a specific Network Load Balancer (NLB).
     Add-Nlb-Vms:
       method: post
       resourcePath: /nlb/{Name}/vms
-      description: "Add a new set of VMs to an existing Network Load Balancer (NLB)."
+      description: Add a new set of VMs to an existing Network Load Balancer (NLB).
     Remove-Nlb-Vms:
       method: delete
       resourcePath: /nlb/{Name}/vms
-      description: "Remove a set of VMs from an existing Network Load Balancer (NLB)."
+      description: Remove a set of VMs from an existing Network Load Balancer (NLB).
     List-Org-Region:
       method: get
       resourcePath: /orgregion
-      description: "Retrieve a list of Original Regions associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName."
+      description: Retrieve a list of Original Regions associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName.
     Count-All-Vms:
       method: get
       resourcePath: /countvm
-      description: "Get the total number of Virtual Machines (VMs) across all connections."
+      description: Get the total number of Virtual Machines (VMs) across all connections.
     Count-All-Vpcs:
       method: get
       resourcePath: /countvpc
-      description: "Get the total number of VPCs across all connections."
+      description: Get the total number of VPCs across all connections.
     Delete-Csp-Key:
       method: delete
       resourcePath: /cspkeypair/{Id}
-      description: "Delete a specified CSP KeyPair."
+      description: Delete a specified CSP KeyPair.
     Register-Disk:
       method: post
       resourcePath: /regdisk
-      description: "Register a new Disk with the specified name, zone, and CSP ID."
+      description: Register a new Disk with the specified name, zone, and CSP ID.
     Count-All-Securitygroups:
       method: get
       resourcePath: /countsecuritygroup
-      description: "Get the total number of Security Groups across all connections."
+      description: Get the total number of Security Groups across all connections.
     Delete-Csp-Vpc:
       method: delete
       resourcePath: /cspvpc/{Id}
-      description: "Delete a specified CSP Virtual Private Cloud (VPC)."
+      description: Delete a specified CSP Virtual Private Cloud (VPC).
     Get-Nlb-Owner-Vpc:
       method: post
       resourcePath: /getnlbowner
-      description: "Retrieve the owner VPC of a specified Network Load Balancer (NLB)."
+      description: Retrieve the owner VPC of a specified Network Load Balancer (NLB).
     Get-Vmgroup-Healthinfo:
       method: get
       resourcePath: /nlb/{Name}/health
-      description: "Retrieve the health information of the VM group in a specified Network Load Balancer (NLB)."
+      description: Retrieve the health information of the VM group in a specified Network Load Balancer (NLB).
     List-Regions:
       method: get
       resourcePath: /region
-      description: "Retrieve a list of registered Regions."
+      description: Retrieve a list of registered Regions.
     Register-Region:
       method: post
       resourcePath: /region
-      description: "Register a new Region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-cloud-regionzone-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+      description: Register a new Region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-cloud-regionzone-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]
     Create-Securitygroup:
       method: post
       resourcePath: /securitygroup
-      description: "Create a new Security Group with specified rules and tags. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Security-Group-Rules-and-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-securitygroup-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+      description: Create a new Security Group with specified rules and tags. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Security-Group-Rules-and-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-securitygroup-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]
     List-Securitygroup:
       method: get
       resourcePath: /securitygroup
-      description: "Retrieve a list of Security Groups associated with a specific connection."
+      description: Retrieve a list of Security Groups associated with a specific connection.
     List-All-Disk:
       method: get
       resourcePath: /alldisk
-      description: "Retrieve a comprehensive list of all Disks associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Disks associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Add-Nodegroup:
       method: post
       resourcePath: /cluster/{Name}/nodegroup
-      description: "Add a new Node Group to an existing Cluster."
+      description: Add a new Node Group to an existing Cluster.
     List-Disk:
       method: get
       resourcePath: /disk
-      description: "Retrieve a list of Disks associated with a specific connection."
+      description: Retrieve a list of Disks associated with a specific connection.
     Create-Disk:
       method: post
       resourcePath: /disk
-      description: "Create a new Disk with the specified configuration. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Disk-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+      description: Create a new Disk with the specified configuration. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Disk-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]
     List-Region-Zone-Preconfig:
       method: get
       resourcePath: /preconfig/regionzone
-      description: "Retrieve a list of pre-configured Region Zones based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+      description: Retrieve a list of pre-configured Region Zones based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]
     Delete-Csp-Nlb:
       method: delete
       resourcePath: /cspnlb/{Id}
-      description: "Delete a specified CSP Network Load Balancer (NLB)."
+      description: Delete a specified CSP Network Load Balancer (NLB).
     List-Region-Zone:
       method: get
       resourcePath: /regionzone
-      description: "Retrieve a list of Region Zones associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+      description: Retrieve a list of Region Zones associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]
     Count-All-Connections:
       method: get
       resourcePath: /countconnectionconfig
-      description: "Get the total number of connections."
+      description: Get the total number of connections.
     Count-Keys-By-Connection:
       method: get
       resourcePath: /countkeypair/{ConnectionName}
-      description: "Get the total number of KeyPairs for a specific connection."
+      description: Get the total number of KeyPairs for a specific connection.
     Increase-Disk-Size:
       method: put
       resourcePath: /disk/{Name}/size
-      description: "Increase the size of an existing disk."
+      description: Increase the size of an existing disk.
     Change-Nodegroup-Scaling:
       method: put
       resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/autoscalesize
-      description: "Change the scaling settings for a Node Group in a Cluster."
+      description: Change the scaling settings for a Node Group in a Cluster.
     List-Myimage:
       method: get
       resourcePath: /myimage
-      description: "Retrieve a list of MyImages associated with a specific connection."
+      description: Retrieve a list of MyImages associated with a specific connection.
     Snapshot-Vm:
       method: post
       resourcePath: /myimage
-      description: "Create a new MyImage snapshot from a specified VM. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/MyImage-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+      description: Create a new MyImage snapshot from a specified VM. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/MyImage-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]
     Unregister-Key:
       method: delete
       resourcePath: /regkeypair/{Name}
-      description: "Unregister a KeyPair with the specified name."
+      description: Unregister a KeyPair with the specified name.
     Start-Vm:
       method: post
       resourcePath: /vm
-      description: "Start a new Virtual Machine (VM) with specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-%EB%A9%80%ED%8B%B0%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C-vm-%EC%9D%B8%ED%94%84%EB%9D%BC-%EC%9E%90%EC%9B%90-%EC%A0%9C%EC%96%B4multi-cloud-vm-infra-resource-control)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+      description: Start a new Virtual Machine (VM) with specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-%EB%A9%80%ED%8B%B0%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C-vm-%EC%9D%B8%ED%94%84%EB%9D%BC-%EC%9E%90%EC%9B%90-%EC%A0%9C%EC%96%B4multi-cloud-vm-infra-resource-control)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]
     List-Vm:
       method: get
       resourcePath: /vm
-      description: "Retrieve a list of Virtual Machines (VMs) associated with a specific connection."
+      description: Retrieve a list of Virtual Machines (VMs) associated with a specific connection.
     Get-Cloudos-Metainfo:
       method: get
       resourcePath: /cloudos/metainfo/{CloudOSName}
-      description: "Retrieve metadata information for a specific Cloud OS."
+      description: Retrieve metadata information for a specific Cloud OS.
     Count-Myimages-By-Connection:
       method: get
       resourcePath: /countmyimage/{ConnectionName}
-      description: "Get the total number of MyImages for a specific connection."
+      description: Get the total number of MyImages for a specific connection.
     Get-Vm-Using-Rs:
       method: get
       resourcePath: /getvmusingresources
-      description: "Retrieve details of a VM using resource ID."
+      description: Retrieve details of a VM using resource ID.
     Unregister-Disk:
       method: delete
       resourcePath: /regdisk/{Name}
-      description: "Unregister a Disk with the specified name."
-
+      description: Unregister a Disk with the specified name.
   mc-iam-manager:
-    Searchrolesbyname:
-      method: get
-      resourcePath: /api/role/name/{roleName}
-      description: "role 검색"
-    Logout:
-      method: post
-      resourcePath: /api/auth/logout
-      description: "AccessToken및 RefreshToken을 받아 해당 토큰 파기"
-    Deleteresourcepermissionpolicesbyoperationid:
-      method: delete
-      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}/remove
-      description: "권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다."
-    listProjects:
-      method: post
-      resourcePath: /api/projects/list
-      description: "project 목록 조회"
-    createProject:
-      method: post
-      resourcePath: /api/projects
-      description: "project 생성"
-    Getresources:
-      method: get
-      resourcePath: /api/resource
-      description: "리소스의 정보를 검색합니다."
-    Createresource:
-      method: post
-      resourcePath: /api/resource
-      description: "리소스를 생성합니다."
-    Getrolelist:
-      method: post
-      resourcePath: /api/roles/list
-      description: "role 전체 목록 조회"
-    Getrolescsproles:
-      method: get
-      resourcePath: /api/roles/csp-roles/id/{roleId}
-      description: "role별 CSP role 목록 조회"
-    listCSPRoles:
-      method: post
-      resourcePath: /api/roles/csp/list
-      description: "CSP에 정의된 역할 목록 조회"
-    Createrole:
-      method: post
-      resourcePath: /api/roles
-      description: "role 생성"
-    Updaterole:
-      method: put
-      resourcePath: /api/roles/id/{roleId}
-      description: "role 수정"
-    Syncrolelistwithkeycloak:
-      method: get
-      resourcePath: /api/tool/keycloak/role/sync
-      description: "연결된 TB(mcinframanager)의 NS 리스트를 Project List 로 등록.  \n  \n기존 등록된 project 와 중복이 발생하면 오류 발생. 새로운 환경에서 첫 회 실행하는 것을 추천."
-    Searchworkspacesbyname:
-      method: get
-      resourcePath: /api/ws/workspace/{workspaceName}
-      description: "workspace 검색"
-    Readyz:
-      method: get
-      resourcePath: /readyz
-      description: "mc-iam-manager가 정상적으로 작동중인지 단순 확인합니다."
-    Getwpmappinglistorderbyworkspace:
-      method: get
-      resourcePath: /api/wsprj
-      description: "workspace - projects mapping workspace 기준 모든 목록 조회"
-    Createwpmapping:
-      method: post
-      resourcePath: /api/wsprj
-      description: "workspace - projects mapping 생성"
-    addProjectToWorkspace:
-      method: post
-      resourcePath: /api/workspaces/assign/projects
-      description: "workspace에 project 등록"
-    Getworkspaceuserrolemappinglistbyworkspaceid:
-      method: get
-      resourcePath: /api/wsuserrole/workspace/id/{workspaceId}
-      description: "workspace - user - role mapping 목록 workspace 기준 조회"
-    Login:
-      method: post
-      resourcePath: /api/auth/login
-      description: "ID/Password를 받아 JWT 세션 토큰을 반환"
-    Gettokeninfo:
-      method: get
-      resourcePath: /api/auth/tokeninfo
-      description: "유저 정보 조회"
-    Getcurrentpermissioncsv:
-      method: get
-      resourcePath: /api/permission/file/framework/{framework}
-      description: "현재 권한을 CSV 형태로 가져옵니다."
-    Importpermissionbycsv:
-      method: post
-      resourcePath: /api/permission/file/framework/{framework}
-      description: "CSV 기반으로 권한을 업데이트 합니다."
-    Getprojectbyid:
-      method: get
-      resourcePath: /api/prj/project/id/{projectId}
-      description: "project 단건 조회"
-    Updateprojectbyid:
-      method: put
-      resourcePath: /api/prj/project/id/{projectId}
-      description: "project 수정"
-    Deleteprojectbyid:
-      method: delete
-      resourcePath: /api/prj/project/id/{projectId}
-      description: "project 삭제"
-    deleteWorkspace:
-      method: delete
-      resourcePath: /api/workspaces/id/{workspaceId}
-      description: "workspace 삭제"
-    getWorkspaceByID:
-      method: get
-      resourcePath: /api/workspaces/id/{workspaceId}
-      description: "workspace 단건 조회"
-    updateWorkspace:
-      method: put
-      resourcePath: /api/workspaces/id/{workspaceId}
-      description: "workspace 수정"
-    Getcerts:
-      method: get
-      resourcePath: /api/auth/certs
-      description: "유저 토큰의 사용가능 유무"
-    Authgetuservalidate:
-      method: get
-      resourcePath: /api/auth/validate
-      description: "유저 토큰의 사용가능 유무"
-    Getpermission:
-      method: get
-      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}
-      description: "권한을 검색합니다."
-    Updateresourcepermissionbyoperationid:
-      method: put
-      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}
-      description: "권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다."
-    Activeuser:
-      method: post
-      resourcePath: /api/user/active
-      description: "권한 있는 사용자가 해당 유저를 활성화합니다."
-    Getworkspaceuserrolemappinglistorderbyworkspace:
-      method: get
-      resourcePath: /api/wsuserrole
-      description: "workspace - user - role mapping 목록 workspace 기준 전체 조회"
-    Createworkspaceuserrolemappingbyname:
-      method: post
-      resourcePath: /api/wsuserrole
-      description: "workspace - user - role mapping 생성"
-    Getallavailablemenus:
-      method: post
-      resourcePath: /api/users/menus/list
-      description: "해당 프레임워크 사용자에게 할당된 메뉴 리스트를 반환합니다."
-    Getmappedmenusbyrolelist:
-      method: post
-      resourcePath: /api/menus/platform-roles/list
-      description: "해당 프레임워크 역할에 할당된 메뉴 리스트를 반환합니다."
-    Deleteuser:
-      method: delete
-      resourcePath: /api/users/id/{userId}
-      description: "사용자를 삭제합니다."
-    Updateuser:
-      method: put
-      resourcePath: /api/users/id/{userId}
-      description: "사용자 정보를 업데이트 합니다."
-    Createworkspace:
-      method: post
-      resourcePath: /api/workspaces
-      description: "workspace 생성"
-    listWorkspaces:
-      method: post
-      resourcePath: /api/workspaces/list
-      description: "workspace 목록 조회"
-    listMciamPermissions:
-      method: post
-      resourcePath: /api/permissions/mciam/list
-      description: "모든 권한을 가져옵니다."
-    listUsersAndRolesByWorkspaces:
-      method: post
-      resourcePath: /api/workspaces/id/{workspaceId}/users/list
-      description: "workspace 목록 조회"
-    getWorkspaceProjectsByWorkspaceId:
-      method: get
-      resourcePath: /api/workspaces/id/{workspaceId}/projects/list
-    ListUsersAndRolesByWorkspaces:
-      method: post
-      resourcePath: /api/workspaces/id/{workspaceId}/users/list
-    listWorkspaceProjects:
-      method: post
-      resourcePath: /api/workspaces/projects/list
-    getTempCredentialProviders:
-      method: get
-      resourcePath: /api/auth/temp-credential-csps
-      description: "임시 자격 증명을 지원하는 CSP 목록 조회"
-    Appendresourcepermissionpolicesbyoperationid:
-      method: put
-      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}/append
-      description: "권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다."
-    Updateresource:
-      method: put
-      resourcePath: /api/resource/id/{id}
-      description: "리소스를 업데이트 합니다."
-    Deleteresource:
-      method: delete
-      resourcePath: /api/resource/id/{id}
-      description: "리소스를 삭제합니다."
-    Getmenuresources:
-      method: post
-      # method: get
-      # resourcePath: /api/resource/menus
-      resourcePath: /api/menus/list
-      description: "메뉴 리소스를 검색합니다."
-    Getallpermissions:
-      method: get
-      resourcePath: /api/ticket
-      description: "사용자는 uma_protection Role 을 가져야 한다."
-    Getpermissionticket:
-      method: post
-      resourcePath: /api/ticket
-      description: "사용자는 uma_protection Role 을 가져야 한다."
-    getProjectsByWorkspaceId:
-      method: get
-      resourcePath: /api/workspaces/id/{workspaceId}/projects/list
-      description: "workspace - projects mapping workspace 기준 목록 조회"
-    listUserWorkspaces:
-      method: post
-      resourcePath: /api/users/workspaces/list
-      description: "workspace - user - role mapping 목록 user 기준 조회"
-    Deleteworkspaceuserrolemapping:
-      method: delete
-      resourcePath: /api/wsuserrole/workspace/id/{workspaceId}/user/id/{userId}
-      description: "workspace - user - role mapping 목록 workspace 와 user 로 mapping 삭제"
-    Loginrefresh:
-      method: post
-      resourcePath: /api/auth/refresh
-      description: "refresh_token과 기존 JWT를 받아, 새로운 JWT 토큰 발급"
-    Getuserinfo:
-      method: get
-      resourcePath: /api/auth/userinfo
-      description: "유저 정보 조회"
-    Updateuseinfonotuse:
-      method: put
-      resourcePath: /api/auth/userinfo
-      description: "유저 정보 조회"
-    Createapiresourcesbyapiyaml:
-      method: post
-      resourcePath: /api/resource/file/framework/{framework}
-      description: "mc-admin-cli 에서 생성한 api yaml을 바탕으로 모든 리소스를 등록합니다.  \n리소스가 중복될시 오류를 반환하고 업데이트 하지 않습니다."
-    Resetresource:
-      method: delete
-      resourcePath: /api/resource/reset
-      description: "모든 리소스를 삭제합니다."
-    Syncprojectlistwithmcinfra:
-      method: get
-      resourcePath: /api/tool/mcinfra/sync
-      description: "연결된 TB(mcinframanager)의 NS 리스트를 Project List 로 등록.  \n  \n기존 등록된 project 와 중복이 발생하면 오류 발생. 새로운 환경에서 첫 회 실행하는 것을 추천."
-    Getdependentpermissionsbypolicyid:
-      method: get
-      resourcePath: /api/permission/policyid/{policyid}
-      description: "권한을 검색합니다."
-    Searchprojectsbyname:
-      method: get
-      resourcePath: /api/prj/project/{projectName}
-      description: "project 목록 검색"
-    Resetmenuresource:
-      method: delete
-      resourcePath: /api/resource/reset/menu
-      description: "모든 메뉴 리소스를 삭제합니다."
-    Deleterolebyid:
-      method: delete
-      resourcePath: /api/roles/id/{roleId}
-      description: "role 삭제"
-    Getrolebyid:
-      method: get
-      resourcePath: /api/role/id/{roleId}
-      description: "role 단건 조회"
-    Updaterolebyid:
-      method: put
-      resourcePath: /api/role/id/{roleId}
-      description: "role 수정"
-    Getrolebypolicyidnotuse:
-      method: get
-      resourcePath: /api/role/policyid/{policyid}
-      description: "role 단건 조회"
-    Createmenuresourcesbymenuyaml:
-      method: post
-      resourcePath: /api/resource/file/framework/{framework}/menu
-      description: "mc-web-console 등 menu yaml을 사용해서 메뉴 리소스를 등록합니다."
-    Listusers:
-      method: post
-      resourcepath: /api/users/list
-      description: "사용자 목록 조회"
-    getUserByID:
-      method: get
-      resourcePath: /api/users/id/{userId}
-      description: "사용자 단건 조회 by id"
-    Getuserbyname:
-      method: get
-      resourcePath: /api/users/name/{username}
-      description: "사용자 단건 조회 by name"
-    Getuserworkspacesbyuserid:
-      method: get
-      resourcePath: /api/users/id/{userId}/workspaces/list
-      description: "특정 사용자의 워크스페이스 목록조회"
-    Createuser:
-      method: post
-      resourcePath: /api/users
-      description: "유저를 등록합니다."
-    Deactiveuser:
-      method: post
-      resourcePath: /api/user/deactive
-      description: "권한 있는 사용자가 해당 유저를 비활성화합니다."
-    removeWorkspaceFromProject:
-      method: delete
-      resourcePath: /api/projects/unassign/workspaces
-      description: "Workspace에서 Project 할당 해제"
     ListMcmpApisServices:
       method: post
       resourcePath: /api/mcmp-apis/list
@@ -1002,31 +690,47 @@ serviceActions:
     UpdateFrameworkService:
       method: put
       resourcePath: /api/mcmp-apis/name/{serviceName}
-      description: "프레임워크 서비스 BaseURL 수정."
-    mciamCheckHealth:
+      description: "프레임워크 서비스 BaseURL 수정. body: {BaseURL: string}"
+    Searchrolesbyname:
       method: get
-      resourcePath: /readyz
-      description: "mc-iam-manager 헬스체크."
-    assignPlatformRole:
+      resourcePath: /api/role/name/{roleName}
+      description: role 검색
+    Logout:
       method: post
-      resourcePath: /api/roles/assign/platform-role
-      description: "Platform Role 할당"
-    removePlatformRole:
+      resourcePath: /api/auth/logout
+      description: AccessToken및 RefreshToken을 받아 해당 토큰 파기
+    Deleteresourcepermissionpolicesbyoperationid:
       method: delete
-      resourcePath: /api/roles/unassign/platform-role
-      description: "사용자에게서 Platform Role 제거"
-    listPlatformRoles:
+      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}/remove
+      description: 권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다.
+    listProjects:
       method: post
-      resourcePath: /api/roles/platform-roles/list
-      description: "Platform Role 목록 조회"
-    AssignRoleToUser:
+      resourcePath: /api/projects/list
+      description: project 목록 조회
+    createProject:
       method: post
-      resourcePath: /api/roles/assign/platform-role
-      description: "사용자에게 플랫폼 역할을 할당합니다."
-    Signup:
+      resourcePath: /api/projects
+      description: project 생성
+    Getresources:
+      method: get
+      resourcePath: /api/resource
+      description: 리소스의 정보를 검색합니다.
+    Createresource:
       method: post
-      resourcePath: /api/auth/signup
-      description: "신규 사용자 회원가입 (관리자 승인 후 로그인 가능)"
+      resourcePath: /api/resource
+      description: 리소스를 생성합니다.
+    Getrolelist:
+      method: post
+      resourcePath: /api/roles/list
+      description: role 전체 목록 조회
+    Getrolescsproles:
+      method: get
+      resourcePath: /api/roles/csp-roles/id/{roleId}
+      description: role별 CSP role 목록 조회
+    listCSPRoles:
+      method: post
+      resourcePath: /api/roles/csp/list
+      description: "CSP에 정의된 역할 목록 조회"
     GetCspRoleById:
       method: get
       resourcePath: /api/roles/csp/id/{roleId}
@@ -1075,114 +779,399 @@ serviceActions:
       method: post
       resourcePath: /api/csp-policies/sync
       description: "CSP Policy 동기화"
+    Createrole:
+      method: post
+      resourcePath: /api/roles
+      description: role 생성
+    Updaterole:
+      method: put
+      resourcePath: /api/roles/id/{roleId}
+      description: role 수정
+    Syncrolelistwithkeycloak:
+      method: get
+      resourcePath: /api/tool/keycloak/role/sync
+      description: "연결된 TB(mcinframanager)의 NS 리스트를 Project List 로 등록.  \n  \n기존 등록된 project 와 중복이 발생하면 오류 발생. 새로운 환경에서 첫 회 실행하는 것을 추천."
+    Searchworkspacesbyname:
+      method: get
+      resourcePath: /api/ws/workspace/{workspaceName}
+      description: workspace 검색
+    Readyz:
+      method: get
+      resourcePath: /readyz
+      description: mc-iam-manager가 정상적으로 작동중인지 단순 확인합니다.
+    Getwpmappinglistorderbyworkspace:
+      method: get
+      resourcePath: /api/wsprj
+      description: workspace - projects mapping workspace 기준 모든 목록 조회
+    Createwpmapping:
+      method: post
+      resourcePath: /api/wsprj
+      description: workspace - projects mapping 생성
+    addProjectToWorkspace:
+      method: post
+      resourcePath: /api/workspaces/assign/projects
+      description: workspace에 project 등록
+    Getworkspaceuserrolemappinglistbyworkspaceid:
+      method: get
+      resourcePath: /api/wsuserrole/workspace/id/{workspaceId}
+      description: workspace - user - role mapping 목록 workspace 기준 조회
+    Signup:
+      method: post
+      resourcePath: /api/auth/signup
+      description: 신규 사용자 회원가입 (관리자 승인 후 로그인 가능)
+    Login:
+      method: post
+      resourcePath: /api/auth/login
+      description: ID/Password를 받아 JWT 세션 토큰을 반환
+    Gettokeninfo:
+      method: get
+      resourcePath: /api/auth/tokeninfo
+      description: 유저 정보 조회
+    Getcurrentpermissioncsv:
+      method: get
+      resourcePath: /api/permission/file/framework/{framework}
+      description: 현재 권한을 CSV 형태로 가져옵니다.
+    Importpermissionbycsv:
+      method: post
+      resourcePath: /api/permission/file/framework/{framework}
+      description: CSV 기반으로 권한을 업데이트 합니다.
+    Getprojectbyid:
+      method: get
+      resourcePath: /api/prj/project/id/{projectId}
+      description: project 단건 조회
+    Updateprojectbyid:
+      method: put
+      resourcePath: /api/prj/project/id/{projectId}
+      description: project 수정
+    Deleteprojectbyid:
+      method: delete
+      resourcePath: /api/prj/project/id/{projectId}
+      description: project 삭제
+    deleteWorkspace:
+      method: delete
+      resourcePath: /api/workspaces/id/{workspaceId}
+      description: workspace 삭제
+    getWorkspaceByID:
+      method: get
+      resourcePath: /api/workspaces/id/{workspaceId}
+      description: workspace 단건 조회
+    updateWorkspace:
+      method: put
+      resourcePath: /api/workspaces/id/{workspaceId}
+      description: workspace 수정
+    Getcerts:
+      method: get
+      resourcePath: /api/auth/certs
+      description: 유저 토큰의 사용가능 유무
+    Authgetuservalidate:
+      method: get
+      resourcePath: /api/auth/validate
+      description: 유저 토큰의 사용가능 유무
+    Getpermission:
+      method: get
+      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}
+      description: 권한을 검색합니다.
+    Updateresourcepermissionbyoperationid:
+      method: put
+      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}
+      description: 권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다.
+    Activeuser:
+      method: post
+      resourcePath: /api/user/active
+      description: 권한 있는 사용자가 해당 유저를 활성화합니다.
+    Getworkspaceuserrolemappinglistorderbyworkspace:
+      method: get
+      resourcePath: /api/wsuserrole
+      description: workspace - user - role mapping 목록 workspace 기준 전체 조회
+    Createworkspaceuserrolemappingbyname:
+      method: post
+      resourcePath: /api/wsuserrole
+      description: workspace - user - role mapping 생성
+    Getallavailablemenus:
+      method: post
+      resourcePath: /api/users/menus/list
+      description: 해당 프레임워크 사용자에게 할당된 메뉴 리스트를 반환합니다.
+    Getmappedmenusbyrolelist:
+      method: post
+      resourcePath: /api/menus/platform-roles/list
+      description: 해당 프레임워크 역할에 할당된 메뉴 리스트를 반환합니다.
+    Deleteuser:
+      method: delete
+      resourcePath: /api/users/id/{userId}
+      description: 사용자를 삭제합니다.
+    Updateuser:
+      method: put
+      resourcePath: /api/users/id/{userId}
+      description: 사용자 정보를 업데이트 합니다.
+    Createworkspace:
+      method: post
+      resourcePath: /api/workspaces
+      description: workspace 생성
+    listWorkspaces:
+      method: post
+      resourcePath: /api/workspaces/list
+      description: workspace 목록 조회
+    listMciamPermissions:
+      method: post
+      resourcePath: /api/permissions/mciam/list
+      description: 모든 권한을 가져옵니다.
+    listUsersAndRolesByWorkspaces:
+      method: post
+      resourcePath: /api/workspaces/id/{workspaceId}/users/list
+      description: workspace 목록 조회
+    getWorkspaceProjectsByWorkspaceId:
+      method: get
+      resourcePath: /api/workspaces/id/{workspaceId}/projects/list
+    ListUsersAndRolesByWorkspaces:
+      method: post
+      resourcePath: /api/workspaces/id/{workspaceId}/users/list
+    listWorkspaceProjects:
+      method: post
+      resourcePath: /api/workspaces/projects/list
+    getTempCredentialProviders:
+      method: get
+      resourcePath: /api/auth/temp-credential-csps
+      description: 임시 자격 증명을 지원하는 CSP 목록 조회
+    Appendresourcepermissionpolicesbyoperationid:
+      method: put
+      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}/append
+      description: 권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다.
+    Updateresource:
+      method: put
+      resourcePath: /api/resource/id/{id}
+      description: 리소스를 업데이트 합니다.
+    Deleteresource:
+      method: delete
+      resourcePath: /api/resource/id/{id}
+      description: 리소스를 삭제합니다.
+    Getmenuresources:
+      method: post
+      resourcePath: /api/menus/list
+      description: 메뉴 리소스를 검색합니다.
     Listmenustree:
       method: post
       resourcePath: /api/menus/menus-tree/list
-      description: "List all menus as tree structure (Admin only)"
+      description: List all menus as tree structure (Admin only)
     Createmenu:
       method: post
       resourcePath: /api/menus
-      description: "Create a new menu"
+      description: Create a new menu
     Getmenubyid:
       method: get
       resourcePath: /api/menus/id/{menuId}
-      description: "Get menu details by ID"
+      description: Get menu details by ID
     Updatemenu:
       method: put
       resourcePath: /api/menus/id/{menuId}
-      description: "Update menu details"
+      description: Update menu details
     Deletemenu:
       method: delete
       resourcePath: /api/menus/id/{menuId}
-      description: "Delete a menu"
+      description: Delete a menu
+    Getallpermissions:
+      method: get
+      resourcePath: /api/ticket
+      description: 사용자는 uma_protection Role 을 가져야 한다.
+    Getpermissionticket:
+      method: post
+      resourcePath: /api/ticket
+      description: 사용자는 uma_protection Role 을 가져야 한다.
+    getProjectsByWorkspaceId:
+      method: get
+      resourcePath: /api/workspaces/id/{workspaceId}/projects/list
+      description: workspace - projects mapping workspace 기준 목록 조회
+    listUserWorkspaces:
+      method: post
+      resourcePath: /api/users/workspaces/list
+      description: workspace - user - role mapping 목록 user 기준 조회
+    Deleteworkspaceuserrolemapping:
+      method: delete
+      resourcePath: /api/wsuserrole/workspace/id/{workspaceId}/user/id/{userId}
+      description: workspace - user - role mapping 목록 workspace 와 user 로 mapping 삭제
+    Loginrefresh:
+      method: post
+      resourcePath: /api/auth/refresh
+      description: refresh_token과 기존 JWT를 받아, 새로운 JWT 토큰 발급
+    Getuserinfo:
+      method: get
+      resourcePath: /api/auth/userinfo
+      description: 유저 정보 조회
+    Updateuseinfonotuse:
+      method: put
+      resourcePath: /api/auth/userinfo
+      description: 유저 정보 조회
+    Createapiresourcesbyapiyaml:
+      method: post
+      resourcePath: /api/resource/file/framework/{framework}
+      description: "mc-admin-cli 에서 생성한 api yaml을 바탕으로 모든 리소스를 등록합니다.  \n리소스가 중복될시 오류를 반환하고 업데이트 하지 않습니다."
+    Resetresource:
+      method: delete
+      resourcePath: /api/resource/reset
+      description: 모든 리소스를 삭제합니다.
+    Syncprojectlistwithmcinfra:
+      method: get
+      resourcePath: /api/tool/mcinfra/sync
+      description: "연결된 TB(mcinframanager)의 NS 리스트를 Project List 로 등록.  \n  \n기존 등록된 project 와 중복이 발생하면 오류 발생. 새로운 환경에서 첫 회 실행하는 것을 추천."
+    Getdependentpermissionsbypolicyid:
+      method: get
+      resourcePath: /api/permission/policyid/{policyid}
+      description: 권한을 검색합니다.
+    Searchprojectsbyname:
+      method: get
+      resourcePath: /api/prj/project/{projectName}
+      description: project 목록 검색
+    Resetmenuresource:
+      method: delete
+      resourcePath: /api/resource/reset/menu
+      description: 모든 메뉴 리소스를 삭제합니다.
+    Deleterolebyid:
+      method: delete
+      resourcePath: /api/roles/id/{roleId}
+      description: role 삭제
+    Getrolebyid:
+      method: get
+      resourcePath: /api/role/id/{roleId}
+      description: role 단건 조회
+    Updaterolebyid:
+      method: put
+      resourcePath: /api/role/id/{roleId}
+      description: role 수정
+    Getrolebypolicyidnotuse:
+      method: get
+      resourcePath: /api/role/policyid/{policyid}
+      description: role 단건 조회
+    Createmenuresourcesbymenuyaml:
+      method: post
+      resourcePath: /api/resource/file/framework/{framework}/menu
+      description: mc-web-console 등 menu yaml을 사용해서 메뉴 리소스를 등록합니다.
+    Listusers:
+      method: post
+      resourcepath: /api/users/list
+      description: 사용자 목록 조회
+    getUserByID:
+      method: get
+      resourcePath: /api/users/id/{userId}
+      description: 사용자 단건 조회 by id
+    Getuserbyname:
+      method: get
+      resourcePath: /api/users/name/{username}
+      description: 사용자 단건 조회 by name
+    Getuserworkspacesbyuserid:
+      method: get
+      resourcePath: /api/users/id/{userId}/workspaces/list
+      description: 특정 사용자의 워크스페이스 목록조회
+    Createuser:
+      method: post
+      resourcePath: /api/users
+      description: 유저를 등록합니다.
+    Deactiveuser:
+      method: post
+      resourcePath: /api/user/deactive
+      description: 권한 있는 사용자가 해당 유저를 비활성화합니다.
+    removeWorkspaceFromProject:
+      method: delete
+      resourcePath: /api/projects/unassign/workspaces
+      description: Workspace에서 Project 할당 해제
+    assignPlatformRole:
+      method: post
+      resourcePath: /api/roles/assign/platform-role
+      description: Platform Role 할당
+    removePlatformRole:
+      method: delete
+      resourcePath: /api/roles/unassign/platform-role
+      description: 사용자에게서 Platform Role 제거
     UpdateUserStatus:
       method: post
       resourcePath: /api/users/id/{userId}/status
-      description: "사용자 승인/비활성화 (enabled true/false)"
+      description: 사용자 승인/비활성화 (enabled true/false)
     ResetUserPassword:
       method: put
       resourcePath: /api/users/id/{userId}/password
-      description: "관리자가 사용자 비밀번호 재설정"
+      description: 관리자가 사용자 비밀번호 재설정
     ChangeMyPassword:
       method: put
       resourcePath: /api/users/me/password
-      description: "사용자 본인 비밀번호 변경"
+      description: 사용자 본인 비밀번호 변경
     Createorganization:
       method: post
       resourcePath: /api/organizations
-      description: "그룹 생성"
+      description: 그룹 생성
     Getorganizations:
       method: get
       resourcePath: /api/organizations
-      description: "그룹 목록/트리 조회 (query: tree=true면 중첩 구조)"
+      description: '그룹 목록/트리 조회 (query: tree=true면 중첩 구조)'
     Getorganizationbyid:
       method: get
       resourcePath: /api/organizations/id/{organizationId}
-      description: "그룹 단건 조회 by ID"
+      description: 그룹 단건 조회 by ID
     Getorganizationbycode:
       method: get
       resourcePath: /api/organizations/code/{code}
-      description: "그룹 단건 조회 by code"
+      description: 그룹 단건 조회 by code
     Updateorganization:
       method: put
       resourcePath: /api/organizations/id/{organizationId}
-      description: "그룹 수정 (부모 변경 시 하위 코드 자동 재생성)"
+      description: 그룹 수정 (부모 변경 시 하위 코드 자동 재생성)
     Deleteorganization:
       method: delete
       resourcePath: /api/organizations/id/{organizationId}
-      description: "그룹 삭제 (하위 그룹·소속 사용자 있으면 400)"
+      description: 그룹 삭제 (하위 그룹·소속 사용자 있으면 400)
     Getorganizationusers:
       method: get
       resourcePath: /api/organizations/id/{organizationId}/users
-      description: "그룹 소속 사용자 목록"
+      description: 그룹 소속 사용자 목록
     Assignuserorganizations:
       method: post
       resourcePath: /api/users/id/{userId}/organizations
-      description: "사용자 그룹 할당 (다중)"
-    assignGroupUsers:
-      method: post
-      resourcePath: /api/groups/id/{groupId}/users
-      description: "그룹에 사용자 일괄 할당 (group 입장)"
+      description: 사용자 그룹 할당 (다중)
     Getuserorganizations:
       method: get
       resourcePath: /api/users/id/{userId}/organizations
-      description: "사용자 소속 그룹 목록"
+      description: 사용자 소속 그룹 목록
     Removeuserorganization:
       method: delete
       resourcePath: /api/users/id/{userId}/organizations/{organizationId}
-      description: "사용자 그룹 제거"
+      description: 사용자 그룹 제거
+    assignGroupPlatformRole:
+      method: post
+      resourcePath: /api/groups/id/{groupId}/platform-roles
+      description: 그룹에 Platform Role 할당
+    getGroupPlatformRoles:
+      method: get
+      resourcePath: /api/groups/id/{groupId}/platform-roles
+      description: 그룹의 Platform Role 목록 조회
     listCspAccounts:
       method: post
       resourcePath: /api/csp-accounts/list
-      description: "CSP 계정 목록 조회 (필터: csp_type)"
+      description: 'CSP 계정 목록 조회 (필터: csp_type)'
     createCspAccount:
       method: post
       resourcePath: /api/csp-accounts
-      description: "CSP 계정 등록"
+      description: CSP 계정 등록
     getCspAccountByID:
       method: get
       resourcePath: /api/csp-accounts/id/{accountId}
-      description: "CSP 계정 단건 조회 by ID"
+      description: CSP 계정 단건 조회 by ID
     updateCspAccount:
       method: put
       resourcePath: /api/csp-accounts/id/{accountId}
-      description: "CSP 계정 수정"
+      description: CSP 계정 수정
     deleteCspAccount:
       method: delete
       resourcePath: /api/csp-accounts/id/{accountId}
-      description: "CSP 계정 삭제"
+      description: CSP 계정 삭제
     validateCspAccount:
       method: post
       resourcePath: /api/csp-accounts/id/{accountId}/validate
-      description: "CSP 계정 자격증명 유효성 검증"
+      description: CSP 계정 자격증명 유효성 검증
     activateCspAccount:
       method: post
       resourcePath: /api/csp-accounts/id/{accountId}/activate
-      description: "CSP 계정 활성화"
+      description: CSP 계정 활성화
     deactivateCspAccount:
       method: post
       resourcePath: /api/csp-accounts/id/{accountId}/deactivate
-      description: "CSP 계정 비활성화"
+      description: CSP 계정 비활성화
     GetProjectSyncDiff:
       method: get
       resourcePath: /api/setup/projects/sync-diff
@@ -1194,745 +1183,3286 @@ serviceActions:
     listMenus:
       method: post
       resourcePath: /api/menus/list
-      description: "메뉴 목록 조회 (전체)"
+      description: "메뉴 목록 조회 (전체). FR-CLOUD-ADMIN-006-08 Setup Status — 메뉴 등록 건수 산출."
     InitialMenus:
       method: post
       resourcePath: /api/setup/initial-menus
-      description: "menu.yaml 기반 메뉴 일괄 재등록 (1_setup_auto.sh init_menu와 동일)"
+      description: "menu.yaml 기반 메뉴 일괄 재등록 (1_setup_auto.sh init_menu와 동일). FR-006-08 Re-sync."
     SyncMcmpApis:
       method: post
       resourcePath: /api/setup/sync-mcmp-apis
-      description: "api.yaml 기반 mcmpApi 카탈로그 재동기화 (1_setup_auto.sh init_api_resources와 동일)"
+      description: "api.yaml 기반 mcmpApi 카탈로그 재동기화 (1_setup_auto.sh init_api_resources와 동일). FR-006-08 Re-sync."
     syncProjects:
       method: post
       resourcePath: /api/setup/sync-projects
-      description: "mc-infra-manager의 namespace 목록을 가져와 project 테이블과 동기화"
-
+      description: "mc-infra-manager의 namespace 목록을 가져와 project 테이블과 동기화 (1_setup_auto.sh sync_projects와 동일). FR-006-08 Re-sync."
   mc-infra-manager:
+    GetInfraReadyzInit:
+      method: put
+      resourcePath: /readyz/init
+      description: "mc-infra-manager 초기화. credential valid 선행 필요. image/spec 등 초기 데이터 로드."
     Lookupspeclist:
       method: post
       resourcePath: /lookupSpecs
       description: "Lookup spec list"
-    Getlatencybenchmark:
-      method: get
-      resourcePath: /ns/{nsId}/benchmarkLatency/mci/{mciId}
-      description: "Run MCI benchmark for network latency"
-    Getallsecuritygroup:
-      method: get
-      resourcePath: /ns/{nsId}/resources/securityGroup
-      description: "List all Security Groups or Security Groups' ID"
-    Postsecuritygroup:
+    AddNLBVMs:
       method: post
-      resourcePath: /ns/{nsId}/resources/securityGroup
-      description: "Create Security Group"
-    Delallsecuritygroup:
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}/node
+      description: Add VMs to NLB
+    AnalyzeProvisioningRisk:
+      method: get
+      resourcePath: /provisioning/risk/{specId}
+      description: 'Evaluate the likelihood of provisioning failure based on historical data for a specific VM specification and image combination.
+
+        This endpoint provides intelligent risk assessment to help prevent deployment failures:
+
+
+        **Risk Analysis Factors:**
+
+        - Historical failure rate for the VM specification
+
+        - Image-specific compatibility with the spec
+
+        - Recent failure patterns and trends
+
+        - Cross-reference of spec+image combination success rates
+
+
+        **Risk Levels:**
+
+        - `high`: Very likely to fail (>80% failure rate or image-specific failures)
+
+        - `medium`: Moderate risk (50-80% failure rate or mixed results)
+
+        - `low`: Low risk (<50% failure rate or no previous failures)
+
+        - `unknown`: Insufficient data for analysis
+
+
+        **Recommended Actions by Risk Level:**
+
+        - **High Risk**: Consider alternative specs or images, verify CSP quotas and permissions
+
+        - **Medium Risk**: Proceed with caution, have backup plans ready
+
+        - **Low Risk**: Safe to proceed with normal deployment
+
+
+        **Integration Points:**
+
+        - Automatically called during MCI review process
+
+        - Can be used in CI/CD pipelines for deployment validation
+
+        - Helpful for capacity planning and resource selection'
+    AnalyzeProvisioningRiskDetailed:
+      method: get
+      resourcePath: /provisioning/risk/detailed
+      description: 'Provides comprehensive risk analysis with separate assessments for VM specification and image risks, plus actionable recommendations.
+
+        This endpoint offers enhanced risk analysis by separating spec-level and image-level risk factors:
+
+
+        **Risk Analysis Breakdown:**
+
+        - **Spec Risk**: Analyzes whether the VM specification itself has compatibility or resource issues
+
+        - **Image Risk**: Evaluates the track record of the specific image with this spec
+
+        - **Overall Risk**: Combines both factors to determine the primary risk source
+
+        - **Recommendations**: Provides actionable guidance based on risk analysis
+
+
+        **Spec Risk Factors:**
+
+        - Number of different images that failed with this spec (indicates spec-level issues)
+
+        - Overall failure rate across all images
+
+        - Success/failure ratio with various images
+
+
+        **Image Risk Factors:**
+
+        - Previous success/failure history of this specific image with this spec
+
+        - Whether this is a new, untested combination
+
+
+        **Recommendation Types:**
+
+        - Change VM specification (when spec is the primary risk factor)
+
+        - Try different image (when image is the primary risk factor)
+
+        - Monitor deployment closely (for new combinations or medium risk)
+
+        - Proceed with confidence (for low-risk combinations)'
+    BulkDeleteGlobalDnsRecord:
       method: delete
-      resourcePath: /ns/{nsId}/resources/securityGroup
-      description: "Delete all Security Groups"
-    Postconfig:
+      resourcePath: /resources/globalDns/records
+      description: 'Delete multiple DNS records from Route53 in a single request.
+
+        Records are grouped by domain and submitted as a single ChangeBatch per domain for efficiency.'
+    CancelExecutionTask:
       method: post
-      resourcePath: /config
-      description: "Create or Update config (TB_SPIDER_REST_URL, TB_DRAGONFLY_REST_URL, ...)"
-    Initallconfig:
-      method: delete
-      resourcePath: /config
-      description: "Init all configs"
-    Getallconfig:
-      method: get
-      resourcePath: /config
-      description: "List all configs"
-    Inspectresources:
-      method: post
-      resourcePath: /inspectResources
-      description: "Inspect Resources (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug, CB-Spider, CSP"
-    Postk8sclusterdynamiccheckrequest:
-      method: post
-      resourcePath: /k8sClusterDynamicCheckRequest
-      description: "Check available ConnectionConfig list before create K8sCluster Dynamically from common spec and image"
-    Deldatadisk:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
-      description: "Delete Data Disk"
-    Getdatadisk:
-      method: get
-      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
-      description: "Get Data Disk"
-    Putdatadisk:
-      method: put
-      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
-      description: "Upsize Data Disk"
-    Putsshkey:
-      method: put
-      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: "Update SSH Key"
-    Delsshkey:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: "Delete SSH Key"
-    Getsshkey:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: "Get SSH Key"
-    Getns:
-      method: get
-      resourcePath: /ns/{nsId}
-      description: "Get namespace"
-    Putns:
-      method: put
-      resourcePath: /ns/{nsId}
-      description: "Update namespace"
-    Delns:
-      method: delete
-      resourcePath: /ns/{nsId}
-      description: "Delete namespace"
-    Checkresource:
-      method: get
-      resourcePath: /ns/{nsId}/checkResource/{resourceType}/{resourceId}
-      description: "Check resources' existence"
-    Getallnlb:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb
-      description: "List all NLBs or NLBs' ID"
-    Postnlb:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb
-      description: "Create NLB"
-    Delallnlb:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb
-      description: "Delete all NLBs"
-    Registercspnativeresources:
-      method: post
-      resourcePath: /registerCspResources
-      description: "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to CB-Tumblebug"
-    Getcontrolmci:
-      method: get
-      resourcePath: /ns/{nsId}/control/mci/{mciId}
-      description: "Control the lifecycle of MCI (refine, suspend, resume, reboot, terminate)"
-    Getmonitordata:
-      method: get
-      resourcePath: /ns/{nsId}/monitoring/mci/{mciId}/metric/{metric}
-      description: "Get monitoring data of specified MCI for specified monitoring metric (cpu, memory, disk, network)"
-    Postobjectstorage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/objectStorage
-      description: "Create a Object Storages\n\nSupported CSPs: AWS, Azure\n- Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral\n\n- Note - Please check the `requiredCSPResource` property which includes CSP specific values.\n\n- Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/117\n"
-    Getallobjectstorage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/objectStorage
-      description: "Get all Object Storages (TBD)"
-    Postutiltovalidatenetwork:
-      method: post
-      resourcePath: /util/net/validate
-      description: "Validate a hierarchical configuration of a VPC network or multi-cloud network consisting of multiple VPC networks"
-    Getavailablek8snodeimage:
-      method: get
-      resourcePath: /availableK8sNodeImage
-      description: "(UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image"
-    Getk8sclusterinfo:
-      method: get
-      resourcePath: /k8sClusterInfo
-      description: "Get kubernetes cluster information"
-    Loadassets:
-      method: get
-      resourcePath: /loadAssets
-      description: "Load Common Resources from internal asset files (Spec, Image)"
-    Getcontrolmcivm:
-      method: get
-      resourcePath: /ns/{nsId}/control/mci/{mciId}/vm/{vmId}
-      description: "Control the lifecycle of VM (suspend, resume, reboot, terminate)"
-    Delallvnet:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/vNet
-      description: "Delete all VNets"
-    Getallvnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet
-      description: "List all VNets or VNets' ID"
-    Postvnet:
-      method: post
-      resourcePath: /ns/{nsId}/resources/vNet
-      description: "Create a new VNet"
-    Postmcivmsnapshot:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/snapshot
-      description: "Snapshot VM and create a Custom Image Object using the Snapshot"
-    Getregion:
-      method: get
-      resourcePath: /provider/{providerName}/region/{regionName}
-      description: "Get registered region info"
-    Postmcidynamiccheckrequest:
-      method: post
-      resourcePath: /mciDynamicCheckRequest
-      description: "Check available ConnectionConfig list before create MCI Dynamically from common spec and image"
-    Postfiletomci:
-      method: post
-      resourcePath: /ns/{nsId}/transferFile/mci/{mciId}
-      description: "Transfer a file to specified MCI to the specified path.\nThe file size should be less than 10MB.\nNot for gerneral file transfer but for specific purpose (small configuration files)."
-    Getbenchmark:
-      method: post
-      resourcePath: /ns/{nsId}/benchmark/mci/{mciId}
-      description: "Run MCI benchmark for a single performance metric and return results"
-    Getnlb:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}
-      description: "Get NLB"
-    Delnlb:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}
-      description: "Delete NLB"
-    Postregistersubnet:
-      method: post
-      resourcePath: /ns/{nsId}/registerCspResource/vNet/{vNetId}/subnet
-      description: "Register Subnet, which was created in CSP"
-    Fetchimages:
-      method: post
-      resourcePath: /ns/{nsId}/resources/fetchImages
-      description: "Fetch images"
-    Getobjectstorage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/objectStorage/{objectStorageId}
-      description: "Get resource info of a Object Storage"
-    Deleteobjectstorage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/objectStorage/{objectStorageId}
-      description: "Delete a Object Storage"
-    Removelabel:
-      method: delete
-      resourcePath: /label/{labelType}/{uid}/{key}
-      description: "Remove a label from a resource identified by its uid"
-    Getbastionnodes:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion
-      description: "Get bastion nodes for a VM"
-    Getspec:
-      method: get
-      resourcePath: /ns/{nsId}/resources/spec/{specId}
-      description: "Get spec"
-    Putspec:
-      method: put
-      resourcePath: /ns/{nsId}/resources/spec/{specId}
-      description: "Update spec"
-    Delspec:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/spec/{specId}
-      description: "Delete spec"
-    Getsqldb:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
-      description: "Get resource info of a SQL datatbase"
-    Deletesqldb:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
-      description: "Delete a SQL datatbase"
-    Getvnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
-      description: "Get VNet"
-    Delvnet:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
-      description: "Delete VNet\n- withsubnets: delete VNet and its subnets\n- refine: delete information of VNet and its subnets if there's no info/resource in Spider/CSP\n- force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP"
-    Testjwtauth:
-      method: get
-      resourcePath: /auth/test
-      description: "Test JWT authentication"
-    Getpublickeyforcredentialencryption:
-      method: get
-      resourcePath: /credential/publicKey
-      description: "Generates an RSA key pair using a 4096-bit key size with the RSA algorithm. The public key is generated using the RSA algorithm with OAEP padding and SHA-256 as the hash function. This key is used to encrypt an AES key that will be used for hybrid encryption of credentials."
-    Recommendk8snode:
-      method: post
-      resourcePath: /k8sClusterRecommendNode
-      description: "Recommend K8sCluster's Node plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
-    Postmcivm:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm
-      description: "Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize for multiple VMs)"
-    Postspec:
-      method: post
-      resourcePath: /ns/{nsId}/resources/spec
-      description: "Register spec"
-    Delallsharedresources:
-      method: delete
-      resourcePath: /ns/{nsId}/sharedResources
-      description: "Delete all Default Resource Objects in the given namespace"
-    Getrequiredk8ssubnetcount:
-      method: get
-      resourcePath: /requiredK8sSubnetCount
-      description: "Get the required subnet count to create a K8sCluster"
-    Checkk8snodegroupsonk8screation:
-      method: get
-      resourcePath: /checkK8sNodeGroupsOnK8sCreation
-      description: "Check whether nodegroups are required during the K8sCluster creation"
-    Getmcigroupids:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/subgroup
-      description: "List SubGroup IDs in a specified MCI"
-    Putvmdatadisk:
-      method: put
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk
-      description: "Attach/Detach available dataDisk"
-    Postvmdatadisk:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk
-      description: "Provisioning (Create and attach) dataDisk"
-    Getvmdatadisk:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk
-      description: "Get available dataDisks for a VM"
-    Getsitetositevpn:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}
-      description: "Get resource info of a site-to-site VPN (Currently, GCP-AWS is supported)"
-    Putsitetositevpn:
-      method: put
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}
-      description: "(To be provided) Update a site-to-site VPN"
-    Deletesitetositevpn:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}
-      description: "Delete a site-to-site VPN (Currently, GCP-AWS is supported)"
-    Getcustomimage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
-      description: "Get customImage"
-    Delcustomimage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
-      description: "Delete customImage"
-    Getallrequests:
-      method: get
-      resourcePath: /requests
-      description: "Get details of all requests with optional filters."
-    Deleteallrequests:
-      method: delete
-      resourcePath: /requests
-      description: "Delete details of all requests"
-    Getcloudinfo:
-      method: get
-      resourcePath: /cloudInfo
-      description: "Get cloud information"
-    Getconnconfiglist:
-      method: get
-      resourcePath: /connConfig
-      description: "List all registered ConnConfig"
-    Deletederegistervnet:
-      method: delete
-      resourcePath: /ns/{nsId}/deregisterCspResource/vNet/{vNetId}
-      description: "Deregister the VNet, which was created in CSP"
-    Putsetk8snodegroupautoscaling:
-      method: put
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoscaling
-      description: "Set a K8sNodeGroup's Autoscaling On/Off"
-    Getallcustomimage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/customImage
-      description: "List all customImages or customImages' ID"
-    Postcustomimage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/customImage
-      description: "Register existing Custom Image in a CSP (option=register)"
-    Delallcustomimage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/customImage
-      description: "Delete all customImages"
-    Filterspecsbyrange:
-      method: post
-      resourcePath: /ns/{nsId}/resources/filterSpecsByRange
-      description: "Filter specs by range"
-    Postsystemmci:
-      method: post
-      resourcePath: /systemMci
-      description: "Create System MCI Dynamically for Special Purpose"
-    Lookupspec:
-      method: post
-      resourcePath: /lookupSpec
-      description: "Lookup spec"
-    Postk8snodegroup:
-      method: post
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup
-      description: "Add a K8sNodeGroup"
-    Getnlbhealth:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/healthz
-      description: "Get NLB Health"
-    Postmcisubgroupscaleout:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId}
-      description: "ScaleOut subGroup in specified MCI"
-    Getmcigroupvms:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId}
-      description: "List VMs with a SubGroup label in a specified MCI"
-    Deletederegistersubnet:
-      method: delete
-      resourcePath: /ns/{nsId}/deregisterCspResource/vNet/{vNetId}/subnet/{subnetId}
-      description: "Deregister Subnet, which was created in CSP"
-    Putchangek8snodegroupautoscalesize:
-      method: put
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize
-      description: "Change a K8sNodeGroup's Autoscale Size"
-    Getallmcipolicy:
-      method: get
-      resourcePath: /ns/{nsId}/policy/mci
-      description: "List all MCI policies"
-    Delallmcipolicy:
-      method: delete
-      resourcePath: /ns/{nsId}/policy/mci
-      description: "Delete all MCI policies"
-    Postimage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/image
-      description: "Register image"
-    Delallimage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/image
-      description: "Delete all images"
-    Getallimage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/image
-      description: "List all images or images' ID"
-    Postsubnet:
-      method: post
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
-      description: "Create Subnet"
-    Getallsubnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
-      description: "List all subnets"
-    Putupgradek8scluster:
-      method: put
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/upgrade
-      description: "Upgrade a K8sCluster's version"
-    Getmcivm:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}
-      description: "Get VM in specified MCI"
-    Delmcivm:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}
-      description: "Delete VM in specified MCI"
-    Postinstallmonitoragenttomci:
-      method: post
-      resourcePath: /ns/{nsId}/monitoring/install/mci/{mciId}
-      description: "Install monitoring agent (CB-Dragonfly agent) to MCI"
-    Getobject:
-      method: get
-      resourcePath: /object
-      description: "Get value of an object"
-    Deleteobject:
-      method: delete
-      resourcePath: /object
-      description: "Delete an object"
-    Getavailablek8sclusterversion:
-      method: get
-      resourcePath: /availableK8sVersion
-      description: "Get available kubernetes cluster version"
-    Lookupimage:
-      method: post
-      resourcePath: /lookupImage
-      description: "Lookup image"
-    Postregistervnet:
-      method: post
-      resourcePath: /ns/{nsId}/registerCspResource/vNet
-      description: "Register the VNet, which was created in CSP"
-    Getallsshkey:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sshKey
-      description: "List all SSH Keys or SSH Keys' ID"
-    Postsshkey:
-      method: post
-      resourcePath: /ns/{nsId}/resources/sshKey
-      description: "Create SSH Key"
-    Delallsshkey:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sshKey
-      description: "Delete all SSH Keys"
-    Getproviderlist:
-      method: get
-      resourcePath: /provider
-      description: "List all registered Providers"
-    Checkk8snodeimagedesignation:
-      method: get
-      resourcePath: /checkK8sNodeImageDesignation
-      description: "Check whether node image designation is possible to create a K8sCluster"
-    Getconfig:
-      method: get
-      resourcePath: /config/{configId}
-      description: "Get config"
-    Initconfig:
-      method: delete
-      resourcePath: /config/{configId}
-      description: "Init config"
-    Registercredential:
-      method: post
-      resourcePath: /credential
-      description: "This API registers credential information using hybrid encryption. The process involves compressing and encrypting sensitive data with AES-256, encrypting the AES key with a 4096-bit RSA public key (retrieved via `GET /credential/publicKey`), and using OAEP padding with SHA-256. All values, including the AES key, must be base64 encoded before sending, and the public key token ID must be included in the request."
-    Getcontrolk8scluster:
-      method: get
-      resourcePath: /ns/{nsId}/control/k8sCluster/{k8sClusterId}
-      description: "Control the creation of K8sCluster (continue, withdraw)"
-    Postmcivmdynamic:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vmDynamic
-      description: "Create VM Dynamically and add it to MCI"
-    Postutiltodesignnetwork:
-      method: post
-      resourcePath: /util/net/design
-      description: "Design a hierarchical network configuration of a VPC network or multi-cloud network consisting of multiple VPC networks"
-    Retrieveregionlistfromcsp:
-      method: get
-      resourcePath: /regionFromCsp
-      description: "RetrieveR all region lists from CSPs"
-    Postteststreamresponse:
-      method: post
-      resourcePath: /testStreamResponse
-      description: "Receives a number and streams the decrementing number every second until zero"
-    Removebastionnodes:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/bastion/{bastionVmId}
-      description: "Remove a bastion VM from all vNets"
-    Addnlbvms:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm
-      description: "Add VMs to NLB"
-    Removenlbvms:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm
-      description: "Delete VMs from NLB"
-    Getallsitetositevpn:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn
-      description: "Get all site-to-site VPNs"
-    Postsitetositevpn:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn
-      description: "Create a site-to-site VPN\n\nThe supported CSP sets are as follows:\n\n- GCP and AWS (Note: It will take about `15 minutes`.)\n\n- GCP and Azure (Note: It will take about `30 minutes`.)"
-    Delfirewallrules:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
-      description: "Delete FirewallRules"
-    Postfirewallrules:
-      method: post
-      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
-      description: "Create FirewallRules"
-    Getobjects:
-      method: get
-      resourcePath: /objects
-      description: "List all objects for a given key"
-    Deleteobjects:
-      method: delete
-      resourcePath: /objects
-      description: "Delete child objects along with the given object"
-    Getallbenchmark:
-      method: post
-      resourcePath: /ns/{nsId}/benchmarkAll/mci/{mciId}
-      description: "Run MCI benchmark for all performance metrics and return results"
-    Postmci:
-      method: post
-      resourcePath: /ns/{nsId}/mci
-      description: "Create MCI"
-    Delallmci:
-      method: delete
-      resourcePath: /ns/{nsId}/mci
-      description: "Delete all MCIs"
-    GetAllMci:
-      method: get
-      resourcePath: /ns/{nsId}/mci
-      description: "List all MCIs or MCIs' ID"
-    Postregistercspnativevm:
-      method: post
-      resourcePath: /ns/{nsId}/registerCspVm
-      description: "Register existing VM in a CSP to Cloud-Barista MCI"
-    Getallsqldb:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sqlDb
-      description: "Get all SQL Databases (TBD)"
-    Postsqldb:
-      method: post
-      resourcePath: /ns/{nsId}/resources/sqlDb
-      description: "Create a SQL Databases\n\nSupported CSPs: AWS, Azure, GCP, NCP\n- Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral, gcp-asia-northeast3, ncpvpc-kr\n\n- Note - Please check the `requiredCSPResource` property which includes CSP specific values.\n\n- Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/110\n"
-    Postk8sclusterdynamic:
-      method: post
-      resourcePath: /ns/{nsId}/k8sClusterDynamic
-      description: "Create K8sCluster Dynamically from common spec and image"
-    Putmonitoragentstatusinstalled:
-      method: put
-      resourcePath: /ns/{nsId}/monitoring/status/mci/{mciId}/vm/{vmId}
-      description: "Set monitoring agent (CB-Dragonfly agent) installation status installed (for Windows VM only)"
-    Postinstallbenchmarkagenttomci:
-      method: post
-      resourcePath: /ns/{nsId}/installBenchmarkAgent/mci/{mciId}
-      description: "Install the benchmark agent to specified MCI"
-    Getk8scluster:
-      method: get
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
-      description: "Get K8sCluster"
-    Deletek8scluster:
-      method: delete
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
-      description: "Delete K8sCluster"
-    Getimage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/image/{imageId}
-      description: "GetImage returns an image object if there are matched images for the given namespace and imageKey(Id, CspResourceName, GuestOS,...)"
-    Putimage:
-      method: put
-      resourcePath: /ns/{nsId}/resources/image/{imageId}
-      description: "Update image"
-    Delimage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/image/{imageId}
-      description: "Delete image"
-    Getsubnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
-      description: "Get Subnet"
-    Delsubnet:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
-      description: "Delete Subnet\n- refine: delete a subnet `object` if there's no resource on CSP or no inforamation on Spider\n- force: force: delete a subnet `resource` on a CSP regardless of the current resource status (e.g., attempt to delete even if in use)"
-    Getregions:
-      method: get
-      resourcePath: /provider/{providerName}/region
-      description: "Get registered region info"
-    Postcmdmci:
-      method: post
-      resourcePath: /ns/{nsId}/cmd/mci/{mciId}
-      description: "Send a command to specified MCI"
-    Fetchspecs:
-      method: post
-      resourcePath: /ns/{nsId}/resources/fetchSpecs
-      description: "Fetch specs"
-    Searchimage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/searchImage
-      description: "Search image"
-    Getresourcesbylabelselector:
-      method: get
-      resourcePath: /resources/{labelType}
-      description: "Get resources based on a label selector. The label selector supports the following operators:\n- `=` : Selects resources where the label key equals the specified value (e.g., `env=production`).\n- `!=` : Selects resources where the label key does not equal the specified value (e.g., `tier!=frontend`).\n- `in` : Selects resources where the label key is in the specified set of values (e.g., `region in (us-west, us-east)`).\n- `notin` : Selects resources where the label key is not in the specified set of values (e.g., `env notin (production, staging)`).\n- `exists` : Selects resources where the label key exists (e.g., `env exists`).\n- `!exists` : Selects resources where the label key does not exist (e.g., `env !exists`)."
-    Getlabels:
-      method: get
-      resourcePath: /label/{labelType}/{uid}
-      description: "Get labels for a resource identified by its uid"
-    Createorupdatelabel:
-      method: put
-      resourcePath: /label/{labelType}/{uid}
-      description: "Create or update a label for a resource identified by its uid"
-    Lookupimagelist:
-      method: post
-      resourcePath: /lookupImages
-      description: "Lookup image list"
-    Recommendvm:
-      method: post
-      resourcePath: /mciRecommendVm
-      description: "Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
-    Getallns:
-      method: get
-      resourcePath: /ns
-      description: "List all namespaces or namespaces' ID"
-    Postns:
-      method: post
-      resourcePath: /ns
-      description: "Create namespace"
-    Delallns:
-      method: delete
-      resourcePath: /ns
-      description: "Delete all namespaces"
-    Forwardanyreqtoany:
-      method: post
-      resourcePath: /forward/{path}
-      description: "Forward any (GET) request to CB-Spider"
-    Checkhttpversion:
+      resourcePath: /ns/{nsId}/cmd/infra/{mciId}/task/{taskId}/cancel
+      description: Cancel a running execution task by task ID. This will send a cancellation signal to the task and update the VM command status.
+    CheckHTTPVersion:
       method: get
       resourcePath: /httpVersion
-      description: "Checks and logs the HTTP version of the incoming request to the server console."
-    Postk8scluster:
+      description: Checks and logs the HTTP version of the incoming request to the server console.
+    CheckK8sNodeGroupsOnK8sCreation:
+      method: get
+      resourcePath: /checkK8sNodeGroupsOnK8sCreation
+      description: Check whether nodegroups are required during the K8sCluster creation
+    CheckK8sNodeImageDesignation:
+      method: get
+      resourcePath: /checkK8sNodeImageDesignation
+      description: Check whether node image designation is possible to create a K8sCluster
+    CheckObjectStorage:
+      method: head
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+      description: Check existence of an object storage (bucket)
+    CheckResource:
+      method: get
+      resourcePath: /ns/{nsId}/checkResource/{resourceType}/{resourceId}
+      description: Check resources' existence
+    ClearAllVmCommandStatus:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatusAll
+      description: Delete all command status records for a VM
+    ComplementSshKeyRemoteCommand:
+      method: put
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}/complement
+      description: Update username and privateKey to enable remote command execution on registered VMs
+    CreateObjectStorage:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage
+      description: Create an object storage (bucket)
+    CreateObjectStorageLagacy:
+      method: put
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: '(To be deprecated) Create an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The `objectStorageName` must be globally unique across all existing buckets in the S3 compatible storage.
+
+        - The bucket namespace is shared by all users of the system.'
+    CreateOrUpdateLabel:
+      method: put
+      resourcePath: /label/{labelType}/{uid}
+      description: Create or update a label for a resource identified by its uid
+    CreateSharedResource:
       method: post
-      resourcePath: /ns/{nsId}/k8sCluster
-      description: "Create K8sCluster<br>Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1614"
-    Deleteallk8scluster:
+      resourcePath: /ns/{nsId}/sharedResource
+      description: Create shared resources for MC-Infra
+    DelAllCustomImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/customImage
+      description: Delete all customImages
+    DelAllDataDisk:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/dataDisk
+      description: Delete all Data Disks
+    DelAllImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/image
+      description: Delete all images
+    DelAllInfra:
+
+      method: delete
+      resourcePath: /ns/{nsId}/infra
+      description: Delete all MCIs
+    DelAllInfraPolicy:
+
+      method: delete
+      resourcePath: /ns/{nsId}/policy/infra
+      description: Delete all MCI policies
+    DelAllNLB:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb
+      description: Delete all NLBs
+    DelAllNs:
+      method: delete
+      resourcePath: /ns
+      description: Delete all namespaces
+    DelAllSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: Delete all Security Groups
+    DelAllSharedResources:
+      method: delete
+      resourcePath: /ns/{nsId}/sharedResources
+      description: Delete all Default Resource Objects in the given namespace
+    DelAllSshKey:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: Delete all SSH Keys
+    DelAllVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: Delete all VNets
+    DelCustomImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
+      description: Delete customImage
+    DelDataDisk:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+      description: Delete Data Disk
+    DelFirewallRules:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
+      description: 'Delete specific FirewallRules: Remove specified rules from the Security Group while keeping other existing rules.
+
+        This API will remove only the specified rules from the Security Group, leaving all other rules intact.
+
+
+        Usage:
+
+        Use this API to remove specific firewall rules from a Security Group. Only the rules matching the provided criteria will be deleted.
+
+        - Rules that exactly match the provided Direction, Protocol, Port, and CIDR will be removed.
+
+        - All other existing rules will remain unchanged.
+
+
+        Notes:
+
+        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+
+        - "Protocol" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).
+
+        - "Direction" must be either "inbound" or "outbound".
+
+        - "CIDR" is the allowed IP range.'
+    DelImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: Delete image
+    DelInfra:
+
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}
+      description: Delete MCI
+    DelInfraPolicy:
+
+      method: delete
+      resourcePath: /ns/{nsId}/policy/infra/{mciId}
+      description: Delete MCI Policy
+    DelInfraNode:
+
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}
+      description: Delete VM in specified MCI
+    DelNLB:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}
+      description: Delete NLB
+    DelNs:
+      method: delete
+      resourcePath: /ns/{nsId}
+      description: Delete namespace
+    DelSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: Delete Security Group
+    DelSpec:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: Delete spec
+    DelSshKey:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: Delete SSH Key
+    DelSubnet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
+      description: 'Delete Subnet
+
+        - refine: delete a subnet `object` if there''s no resource on CSP or no inforamation on Spider
+
+        - force: force: delete a subnet `resource` on a CSP regardless of the current resource status (e.g., attempt to delete even if in use)'
+    DelVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+      description: 'Delete VNet
+
+        - withsubnets: delete VNet and its subnets
+
+        - refine: delete information of VNet and its subnets if there''s no info/resource in Spider/CSP
+
+        - force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP'
+    DeleteAllK8sCluster:
       method: delete
       resourcePath: /ns/{nsId}/k8sCluster
-      description: "Delete all K8sClusters"
-    Getallk8scluster:
-      method: get
-      resourcePath: /ns/{nsId}/k8sCluster
-      description: "List all K8sClusters or K8sClusters' ID"
-    Postk8snodegroupdynamic:
+      description: Delete all K8sClusters
+    DeleteAllInfraDynamicTemplate:
+
+      method: delete
+      resourcePath: /ns/{nsId}/template/infra
+      description: Delete all MCI Dynamic Templates in a namespace.
+    DeleteAllRequests:
+      method: delete
+      resourcePath: /requests
+      description: Delete details of all requests
+    DeleteAllSecurityGroupTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/securityGroup
+      description: Delete all SecurityGroup Templates in a namespace.
+    DeleteAllVNetTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/vNet
+      description: Delete all vNet Templates in a namespace.
+    DeleteDataObject:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
+      description: Delete an object from an object storage (bucket)
+    DeleteDataObjectLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
+      description: (To be deprecated) Delete an object from a bucket
+    DeleteDeregisterSubnet:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/vNet/{vNetId}/subnet/{subnetId}
+      description: Deregister Subnet, which was created in CSP
+    DeleteDeregisterVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/vNet/{vNetId}
+      description: Deregister the VNet, which was created in CSP
+    DeleteGlobalDnsRecord:
+      method: delete
+      resourcePath: /resources/globalDns/record
+      description: 'Delete DNS record(s) from Route53. If setIdentifier is provided, deletes only that specific record.
+
+        If setIdentifier is empty, deletes all records matching the name and type.'
+    DeleteK8sCluster:
+      method: delete
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
+      description: Delete K8sCluster
+    DeleteK8sNodeGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}
+      description: Remove a K8sNodeGroup
+    DeleteInfraDynamicTemplate:
+
+      method: delete
+      resourcePath: /ns/{nsId}/template/infra/{templateId}
+      description: Delete a specific MCI Dynamic Template.
+    DeleteMultipleDataObjectsLagacy:
       method: post
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroupDynamic
-      description: "Create K8sNodeGroup Dynamically from common spec and image"
-    Getrequest:
-      method: get
-      resourcePath: /request/{reqId}
-      description: "Get details of a specific request"
-    Deleterequest:
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: '(To be deprecated) `Delete` multiple objects from a bucket
+
+
+        **Important Notes:**
+
+        - The request body must contain the list of objects to delete in XML format
+
+        - The `delete` query parameter must be set to `true`
+
+
+        **Request Body Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Object>
+
+        <Key>test-object1.txt</Key>
+
+        </Object>
+
+        <Object>
+
+        <Key>test-object2.txt</Key>
+
+        </Object>
+
+        </Delete>
+
+        ```
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Deleted>
+
+        <Key>test-object1.txt</Key>
+
+        </Deleted>
+
+        <Deleted>
+
+        <Key>test-object2.txt</Key>
+
+        </Deleted>
+
+        </DeleteResult>
+
+        ```'
+    DeleteObject:
+      method: delete
+      resourcePath: /object
+      description: Delete an object
+    DeleteObjectStorageCORS:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+      description: Delete all CORS rules of an object storage (bucket)
+    DeleteObjectStorageCORSLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}/cors
+      description: (To be deprecated) Delete CORS configuration of an object storage (bucket)
+    DeleteObjectStorageLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: (To be deprecated) Delete an object storage (bucket)
+    DeleteObjects:
+      method: delete
+      resourcePath: /objects
+      description: Delete child objects along with the given object
+    DeleteProvisioningLog:
+      method: delete
+      resourcePath: /provisioning/log/{specId}
+      description: 'Remove all provisioning history data for a specific VM specification.
+
+        This operation permanently deletes historical failure and success records:
+
+
+        **Warning**: This action is irreversible and will remove:
+
+        - All failure and success statistics
+
+        - Historical error messages and troubleshooting data
+
+        - Risk analysis baseline for future deployments
+
+        - Failure pattern analysis data
+
+
+        **When to Use:**
+
+        - **Data Cleanup**: Remove outdated or irrelevant provisioning history
+
+        - **Fresh Start**: Clear history after infrastructure changes that resolve previous issues
+
+        - **Privacy Compliance**: Remove logs containing sensitive error information
+
+        - **Storage Management**: Clean up logs to manage kvstore space
+
+
+        **Impact on System:**
+
+        - Future risk analysis for this spec will have no historical baseline
+
+        - MCI review process will not show historical warnings for this spec
+
+        - Provisioning reliability metrics will be reset to zero'
+    DeleteRequest:
       method: delete
       resourcePath: /request/{reqId}
-      description: "Delete details of a specific request"
-    Getconnconfig:
+      description: Delete details of a specific request
+    DeleteScheduleRegisterCspResources:
+      method: delete
+      resourcePath: /registerCspResources/schedule/{jobId}
+      description: 'Stop and permanently delete a scheduled CSP resource registration job
+
+
+        **Warning:** This operation is irreversible!
+
+        - Job will be stopped immediately
+
+        - All job data and execution history will be deleted
+
+        - Cannot be recovered after deletion
+
+
+        **Alternatives:**
+
+        - To temporarily stop: Use `/pause` endpoint instead
+
+        - To keep history: Set `enabled: false` via PUT endpoint'
+    DeleteScheduleRegisterCspResourcesAll:
+      method: delete
+      resourcePath: /registerCspResources/schedule
+      description: '⚠️ **DANGER: This operation deletes ALL scheduled jobs in the system!**
+
+
+        **⚠️ CRITICAL WARNINGS:**
+
+        - This will PERMANENTLY DELETE **ALL** scheduled jobs across all namespaces
+
+        - All job execution history will be lost
+
+        - This operation is IRREVERSIBLE and cannot be undone
+
+        - Use with EXTREME CAUTION in production environments
+
+
+        **Use Cases:**
+
+        - Cleaning up test/development environments
+
+        - Emergency shutdown of all scheduled operations
+
+        - System maintenance or reset
+
+
+        **Safer Alternatives:**
+
+        - Delete individual jobs: Use `DELETE /registerCspResources/schedule/{jobId}`
+
+        - Temporarily stop all jobs: Pause each job individually via `/pause` endpoint
+
+        - Disable without deleting: Update each job with `enabled: false`
+
+
+        **Response Information:**
+
+        - Returns the count of deleted jobs
+
+        - Returns 200 even if no jobs were found (count will be 0)'
+    DeleteSecurityGroupTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+      description: Delete a specific SecurityGroup Template.
+    DeleteSiteToSiteVpn:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn/{vpnId}
+      description: 'Delete a site-to-site VPN
+
+
+        - Note: A one-time retry is performed to handle transient failures caused by CSP-internal timing issues between dependent resources.
+
+        '
+    DeleteSqlDb:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
+      description: Delete a SQL datatbase
+    DeleteVNetTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/vNet/{templateId}
+      description: Delete a specific vNet Template.
+    DeleteVersionedObject:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions/{objectKey}
+      description: 'Delete a specific version of an object in an object storage (bucket)
+
+
+        **Note: **
+
+        - If no version is specified, we will define how it behaves and update it when necessary.
+
+        '
+    DeleteVersionedObjectLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}/versions/{objectKey}
+      description: (To be deprecated) Delete a specific version of an object in an object storage (bucket)
+    DeleteVmCommandStatus:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatus/{index}
+      description: Delete a specific command status record by index for a VM
+    DeleteVmCommandStatusByCriteria:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatus
+      description: Delete multiple command status records for a VM based on filtering criteria
+    DeleteVmSshHostKey:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/sshHostKey
+      description: Reset the stored SSH host key for a specific VM. This should be used when the VM's host key has legitimately changed (e.g., after VM recreation) and you trust the new key. The next SSH connection will store the new host key (TOFU).
+    DeregisterCustomImage:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/customImage/{customImageId}
+      description: Deregister customImage from Spider and TB without deleting the actual CSP resource
+    DeregisterDataDisk:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/dataDisk/{dataDiskId}
+      description: Deregister Data Disk from Spider and TB without deleting the actual CSP resource
+    DeregisterInfraNode:
+
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/infra/{mciId}/node/{vmId}
+      description: Deregister VM from Spider and TB without deleting the actual CSP resource
+    DeregisterSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/securityGroup/{securityGroupId}
+      description: Deregister Security Group from Spider and TB without deleting the actual CSP resource
+    DeregisterSshKey:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/sshKey/{sshKeyId}
+      description: Deregister SSH Key from Spider and TB without deleting the actual CSP resource
+    ExistObjectStorageLagacy:
+      method: head
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: (To be deprecated) Check existence of an object storage (bucket)
+    FetchImages:
+      method: post
+      resourcePath: /fetchImages
+      description: 'Fetch images waiting for completion.
+
+
+        **Provider Selection Options:**
+
+        - `targetProviders`: Specify exact providers to fetch (e.g., ["aws", "gcp"]). When set, only these providers are processed and `excludedProviders` is ignored.
+
+        - `excludedProviders`: Specify providers to skip (e.g., ["azure"]). Only used when `targetProviders` is not set.
+
+        - `regionAgnosticProviders`: Providers where images are shared across regions (e.g., ["gcp", "tencent"]). Only one region will be fetched per provider.
+
+
+        **Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded).'
+    FetchImagesAsync:
+      method: post
+      resourcePath: /fetchImagesAsync
+      description: 'Fetch images in the background without waiting for completion.
+
+
+        **Provider Selection Options:**
+
+        - `targetProviders`: Specify exact providers to fetch (e.g., ["aws", "gcp"]). When set, only these providers are processed and `excludedProviders` is ignored.
+
+        - `excludedProviders`: Specify providers to skip (e.g., ["azure"]). Only used when `targetProviders` is not set.
+
+        - `regionAgnosticProviders`: Providers where images are shared across regions (e.g., ["gcp", "tencent"]). Only one region will be fetched per provider.
+
+
+        **Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded).'
+    FetchPrice:
+      method: post
+      resourcePath: /fetchPrice
+      description: Fetch price from all CSP connections and update the price information for associated specs in the system.
+    FetchSpecs:
+      method: post
+      resourcePath: /fetchSpecs
+      description: 'Fetch specs from CSPs and register them in the system.
+
+
+        **Provider Selection Options:**
+
+        - `targetProviders`: Specify exact providers to fetch (e.g., ["aws", "gcp"]). When set, only these providers are processed and `excludedProviders` is ignored.
+
+        - `excludedProviders`: Specify providers to skip (e.g., ["azure"]). Only used when `targetProviders` is not set.
+
+        - `regionAgnosticProviders`: Providers where specs are shared across regions (e.g., ["gcp", "tencent"]). Only one region will be fetched per provider.
+
+
+        **Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded).'
+    FilterSpecsByRange:
+      method: post
+      resourcePath: /ns/{nsId}/resources/filterSpecsByRange
+      description: Filter specs by range. Use limit field to control the maximum number of results. If limit is 0 or not specified, returns all matching results.
+    ForwardAnyReqToAny:
+      method: post
+      resourcePath: /forward/{path}
+      description: Forward any (GET) request to CB-Spider
+    GeneratePresignedDownloadURLLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/presigned/download/{objectStorageName}/{objectKey}
+      description: '(To be deprecated) Generate a presigned URL for downloading an object from a bucket
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `PresignedURLResult`
+
+        - The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)
+
+        - The generated presigned URL can be used to download the object directly without further authentication
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <PresignedURLResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>
+
+        <Expires>3600</Expires>
+
+        <Method>GET</Method>
+
+        </PresignedURLResult>
+
+        ```'
+    GeneratePresignedURL:
+      method: post
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}/presignedUrl
+      description: 'Generate a presigned URL for uploading  or downloading an object to an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The generated presigned URL can be used to upload the object directly without further authentication
+
+        - The expiration time is specified in seconds (default: 3600 seconds)
+
+
+        **Example Usage: Upload**
+
+        ```bash
+
+        # Using the presigned URL to upload a file
+
+        curl -i -H "Content-Type: text/plain" -X PUT "<PRESIGNED_URL>" --data-binary "@local-file.txt"
+
+        ```
+
+
+        **Example Usage: download**
+
+        ```bash
+
+        # Using the presigned URL to download a file
+
+        curl -X GET "<PRESIGNED_URL>" -o downloaded-file.txt
+
+        ```'
+    GeneratePresignedUploadURLLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/presigned/upload/{objectStorageName}/{objectKey}
+      description: '(To be deprecated) Generate a presigned URL for uploading an object to a bucket
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `PresignedURLResult`
+
+        - The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)
+
+        - The generated presigned URL can be used to upload the object directly without further authentication
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <PresignedURLResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>
+
+        <Expires>3600</Expires>
+
+        <Method>PUT</Method>
+
+        </PresignedURLResult>
+
+        ```'
+    GetAllBenchmark:
+      method: post
+      resourcePath: /ns/{nsId}/benchmarkAll/infra/{mciId}
+      description: Run MCI benchmark for all performance metrics and return results
+    GetAllConfig:
+      method: get
+      resourcePath: /config
+      description: List all configs
+    GetAllCustomImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/customImage
+      description: List all customImages or customImages' ID
+    GetAllDataDisk:
+      method: get
+      resourcePath: /ns/{nsId}/resources/dataDisk
+      description: List all Data Disks or Data Disks' ID
+    GetAllImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/image
+      description: List all images or images' ID
+    GetAllK8sCluster:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster
+      description: List all K8sClusters or K8sClusters' ID
+    GetAllInfra:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra
+      description: List all MCIs or MCIs' ID
+    GetAllInfraDynamicTemplate:
+
+      method: get
+      resourcePath: /ns/{nsId}/template/infra
+      description: 'List all MCI Dynamic Templates in a namespace.
+
+        Optionally filter by keyword matching against template name or description (case-insensitive).'
+    GetAllInfraPolicy:
+
+      method: get
+      resourcePath: /ns/{nsId}/policy/infra
+      description: List all MCI policies
+    GetAllNLB:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb
+      description: List all NLBs or NLBs' ID
+    GetAllNs:
+      method: get
+      resourcePath: /ns
+      description: List all namespaces or namespaces' ID
+    GetAllRequests:
+      method: get
+      resourcePath: /requests
+      description: Get details of all requests with optional filters.
+    GetAllSecurityGroup:
+      method: get
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: List all Security Groups or Security Groups' ID
+    GetAllSecurityGroupTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/securityGroup
+      description: 'List all SecurityGroup Templates in a namespace.
+
+        Optionally filter by keyword matching against template name or description (case-insensitive).'
+    GetAllSiteToSiteVpn:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn
+      description: Get all site-to-site VPNs
+    GetAllSqlDb:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sqlDb
+      description: Get all SQL Databases (TBD)
+    GetAllSshKey:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: List all SSH Keys or SSH Keys' ID
+    GetAllSubnet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
+      description: List all subnets
+    GetAllVNet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: List all VNets or VNets' ID
+    GetAllVNetTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/vNet
+      description: 'List all vNet Templates in a namespace.
+
+        Optionally filter by keyword matching against template name or description (case-insensitive).'
+    GetAvailableK8sNodeImage:
+      method: get
+      resourcePath: /availableK8sNodeImage
+      description: (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
+    GetAvailableK8sVersion:
+      method: get
+      resourcePath: /availableK8sVersion
+      description: Get available kubernetes cluster version
+    GetAvailableRegionZonesForSpec:
+      method: post
+      resourcePath: /availableRegionZonesForSpec
+      description: Query the availability of a specific spec across all regions/zones
+    GetAvailableRegionZonesForSpecList:
+      method: post
+      resourcePath: /availableRegionZonesForSpecList
+      description: Query the availability for multiple specs in parallel and return batch results
+    GetAvailableZonesForSpec:
+      method: get
+      resourcePath: /availableZonesForSpec
+      description: Query verified zones for a spec based on connection configs. Returns zones that are both verified and available for the specified spec. For Alibaba Cloud, additional CSP API filtering is applied.
+    GetBastionNodes:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{targetVmId}/bastion
+      description: Get bastion nodes for a VM
+    GetBenchmark:
+      method: post
+      resourcePath: /ns/{nsId}/benchmark/infra/{mciId}
+      description: Run MCI benchmark for a single performance metric and return results
+    GetCloudInfo:
+      method: get
+      resourcePath: /cloudInfo
+      description: Get cloud information
+    GetCmdInfraStream:
+
+      method: get
+      resourcePath: /ns/{nsId}/stream/cmd/infra/{mciId}
+      description: 'Subscribe to Server-Sent Events (SSE) for real-time command execution logs.
+
+        Use the xRequestId returned from POST /ns/{nsId}/cmd/mci/{mciId}?async=true to connect.
+
+        Events: CommandStatus (status transitions), CommandLog (stdout/stderr lines), CommandDone (terminal).'
+    GetConfig:
+      method: get
+      resourcePath: /config/{configId}
+      description: Get config
+    GetConnConfig:
       method: get
       resourcePath: /connConfig/{connConfigName}
-      description: "Get registered ConnConfig info"
-    Getsystemlabelinfo:
+      description: Get registered ConnConfig info
+    GetConnConfigList:
       method: get
-      resourcePath: /labelInfo
-      description: "Return LabelTypes and system defined label keys with example"
-    Postmcnlb:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/mcSwNlb
-      description: "Create a special purpose MCI for NLB and depoly and setting SW NLB"
-    Getmcipolicy:
+      resourcePath: /connConfig
+      description: List all registered ConnConfig
+    FilterConnConfigByCredentialHolder:
       method: get
-      resourcePath: /ns/{nsId}/policy/mci/{mciId}
-      description: "Get MCI Policy"
-    Postmcipolicy:
-      method: post
-      resourcePath: /ns/{nsId}/policy/mci/{mciId}
-      description: "Create MCI Automation policy"
-    Delmcipolicy:
-      method: delete
-      resourcePath: /ns/{nsId}/policy/mci/{mciId}
-      description: "Delete MCI Policy"
-    Postutiltodesignvnet:
-      method: post
-      resourcePath: /util/vNet/design
-      description: "Design VNet and subnets based on user-friendly properties"
-    Registercspnativeresourcesall:
-      method: post
-      resourcePath: /registerCspResourcesAll
-      description: "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from all Clouds to CB-Tumblebug"
-    Delmci:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}
-      description: "Delete MCI"
-    Getmci:
+      resourcePath: /connConfig
+      description: Filter connection configs by credential holder name (queryParams.filterCredentialHolder)
+    GetControlK8sCluster:
       method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}
-      description: "Get MCI object (option: status, accessInfo, vmId)"
-    Getrequeststatusofsitetositevpn:
+      resourcePath: /ns/{nsId}/control/k8sCluster/{k8sClusterId}
+      description: Control the creation of K8sCluster (continue, withdraw)
+    GetControlInfra:
+
       method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}/request/{requestId}
-      description: "Check the status of a specific request by its ID"
-    Getreadyz:
+      resourcePath: /ns/{nsId}/control/infra/{mciId}
+      description: Control the lifecycle of MCI (refine, suspend, resume, reboot, terminate)
+    GetControlInfraNode:
+
+      method: get
+      resourcePath: /ns/{nsId}/control/infra/{mciId}/node/{vmId}
+      description: Control the lifecycle of VM (suspend, resume, reboot, terminate)
+    GetCredentialHolder:
+      method: get
+      resourcePath: /credentialHolder/{holderId}
+      description: Get credential holder info derived from registered connection configs.
+    GetCredentialHolderList:
+      method: get
+      resourcePath: /credentialHolder
+      description: 'List all credential holders derived from registered connection configs.
+
+        Each holder includes associated providers, connection counts, and verification status.'
+    GetCustomImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
+      description: Get customImage
+    GetDataDisk:
+      method: get
+      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+      description: Get Data Disk
+    GetDataObjectInfo:
+      method: head
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
+      description: 'Get object info from an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - This API retrieves the metadata of an object without downloading the actual content
+
+        - Returns metadata in response headers (Content-Length, Content-Type, ETag, Last-Modified)'
+    GetDataObjectInfoLagacy:
+      method: head
+      resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
+      description: '(To be deprecated) Get an object info from a bucket
+
+
+        **Important Notes:**
+
+        - The generated `Download file` link in Swagger UI may not work because this API get the object metadata only.'
+    GetExecutionTask:
+      method: get
+      resourcePath: /ns/{nsId}/cmd/infra/{mciId}/task/{taskId}
+      description: Get detailed information about a specific execution task by taskId
+    GetFetchImagesAsyncResult:
+      method: get
+      resourcePath: /fetchImagesResult
+      description: Get detailed results from the last asynchronous image fetch operation
+    GetGlobalDnsRecord:
+      method: get
+      resourcePath: /resources/globalDns/record
+      description: Get DNS records for a domain from Route53. Includes routing policy and geoproximity info.
+    GetHostedZones:
+      method: get
+      resourcePath: /resources/globalDns/hostedZone
+      description: List all hosted zones available in Route53
+    GetImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: GetImage returns an image object if there are matched images for the given namespace and imageKey(imageId)
+    GetK8sCluster:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
+      description: Get K8sCluster
+    GetK8sClusterInfo:
+      method: get
+      resourcePath: /k8sClusterInfo
+      description: Get kubernetes cluster information
+    GetK8sClusterToken:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/token
+      description: 'Get an access token for the specified K8sCluster.
+
+        Only applicable to CSPs that use exec-based authentication (e.g., GCP GKE, AWS EKS).'
+    GetLabels:
+      method: get
+      resourcePath: /label/{labelType}/{uid}
+      description: Get labels for a resource identified by its uid
+    GetLatencyBenchmark:
+      method: get
+      resourcePath: /ns/{nsId}/benchmarkLatency/infra/{mciId}
+      description: Run MCI benchmark for network latency
+    GetInfra:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}
+      description: 'Get MCI object (option: status, accessInfo, vmId)'
+    GetInfraAssociatedResources:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/associatedResources
+      description: Get associated resource ID list for a given MCI (VNet, Subnet, SecurityGroup, SSHKey, etc.)
+    GetInfraDynamicTemplate:
+
+      method: get
+      resourcePath: /ns/{nsId}/template/infra/{templateId}
+      description: Retrieve a specific MCI Dynamic Template by ID.
+    GetInfraExecutionTasks:
+
+      method: get
+      resourcePath: /ns/{nsId}/cmd/infra/{mciId}/task
+      description: List all running and completed execution tasks for a specific MCI. These tasks can be cancelled if still in progress. The task list is based on persistent VM command status records.
+    GetInfraGroupIds:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodegroup
+      description: List SubGroup IDs in a specified MCI
+    GetInfraGroupNodes:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodegroup/{subgroupId}
+      description: List VMs with a SubGroup label in a specified MCI
+    GetInfraHandlingCommandCount:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/handlingCount
+      description: Get the number of commands currently in 'Handling' status for all VMs in an MCI. Returns per-VM counts and total count.
+    GetInfraPolicy:
+
+      method: get
+      resourcePath: /ns/{nsId}/policy/infra/{mciId}
+      description: Get MCI Policy
+    GetInfraReqFromInfra:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/configCopy
+      description: 'Reconstruct an MCI dynamic creation request body from an existing MCI''s information.
+
+        Returns a dynamic request format where networking resources (vNet, subnet, SG, sshKey)
+
+        are auto-created, making it easy to clone or recreate a similar MCI configuration.
+
+
+        **Template Option:**
+
+        When the `template` query parameter is provided, the extracted configuration is
+
+        saved as a reusable MCI Dynamic Template with the given name.'
+    GetInfraNode:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}
+      description: Get VM in specified MCI
+    GetMonitorData:
+      method: get
+      resourcePath: /ns/{nsId}/monitoring/infra/{mciId}/metric/{metric}
+      description: Get monitoring data of specified MCI for specified monitoring metric (cpu, memory, disk, network)
+    GetNLB:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}
+      description: Get NLB
+    GetNLBHealth:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}/healthz
+      description: Get NLB Health
+    GetNs:
+      method: get
+      resourcePath: /ns/{nsId}
+      description: Get namespace
+    GetObject:
+      method: get
+      resourcePath: /object
+      description: Get value of an object
+    GetObjectStorage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+      description: Get details of an object storage (bucket)
+    GetObjectStorageCORS:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+      description: Get CORS configuration of an object storage (bucket)
+    GetObjectStorageCORSLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/cors
+      description: '(To be deprecated) Get CORS configuration of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `CORSConfiguration`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <CORSRule>
+
+        <AllowedOrigin>*</AllowedOrigin>
+
+        <AllowedMethod>GET</AllowedMethod>
+
+        <AllowedMethod>PUT</AllowedMethod>
+
+        <AllowedMethod>POST</AllowedMethod>
+
+        <AllowedMethod>DELETE</AllowedMethod>
+
+        <AllowedHeader>*</AllowedHeader>
+
+        <ExposeHeader>ETag</ExposeHeader>
+
+        <ExposeHeader>x-amz-server-side-encryption</ExposeHeader>
+
+        <ExposeHeader>x-amz-request-id</ExposeHeader>
+
+        <ExposeHeader>x-amz-id-2</ExposeHeader>
+
+        <MaxAgeSeconds>3000</MaxAgeSeconds>
+
+        </CORSRule>
+
+        </CORSConfiguration>
+
+        ```
+
+
+        **Error Response Example (if CORS not configured):**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <Error>
+
+        <Code>NoSuchCORSConfiguration</Code>
+
+        <Message>The CORS configuration does not exist</Message>
+
+        <Resource>/example-bucket</Resource>
+
+        <RequestId>656c76696e6727732072657175657374</RequestId>
+
+        </Error>
+
+        ```'
+    GetObjectStorageLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: '(To be deprecated) Get details of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `ListBucketResult`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Name>spider-test-bucket</Name>
+
+        <Prefix></Prefix>
+
+        <Marker></Marker>
+
+        <MaxKeys>1000</MaxKeys>
+
+        <IsTruncated>false</IsTruncated>
+
+        </ListBucketResult>
+
+        ```'
+    GetObjectStorageLocation:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/location
+      description: Get the location of an object storage (bucket)
+    GetObjectStorageLocationLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/location
+      description: '(To be deprecated) Get the location of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `LocationConstraint`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">ap-northeast-2</LocationConstraint>
+
+        ```'
+    GetObjectStorageSupport:
+      method: get
+      resourcePath: /objectStorage/support
+      description: 'Get CSP support information for object storage features (CORS, Versioning)
+
+        If cspType query parameter is provided, returns support information for that specific CSP
+
+        If cspType is not provided, returns support information for all CSPs'
+    GetObjectStorageVersioning:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
+      description: Get versioning configuration of an object storage (bucket)
+    GetObjectStorageVersioningLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/versioning
+      description: '(To be deprecated) Get versioning status of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `VersioningConfiguration`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Status>Enabled</Status>
+
+        </VersioningConfiguration>
+
+        ```'
+    GetObjects:
+      method: get
+      resourcePath: /objects
+      description: List all objects for a given key
+    GetProviderList:
+      method: get
+      resourcePath: /provider
+      description: List all registered Providers
+    GetProvisioningLog:
+      method: get
+      resourcePath: /provisioning/log/{specId}
+      description: 'Retrieve detailed provisioning history for a specific VM specification including success/failure patterns and risk analysis.
+
+        This endpoint provides comprehensive insights into provisioning reliability:
+
+
+        **Historical Data Includes:**
+
+        - Success and failure counts with timestamps
+
+        - CSP-specific error messages and failure patterns
+
+        - Image compatibility tracking across different attempts
+
+        - Failure rate analysis and risk assessment
+
+        - Regional and provider-specific reliability metrics
+
+
+        **Use Cases:**
+
+        - **Pre-deployment Risk Assessment**: Check if a spec has historical failures before creating MCI
+
+        - **Troubleshooting**: Analyze failure patterns to identify root causes
+
+        - **Capacity Planning**: Understand reliability patterns for different specs and regions
+
+        - **Cost Optimization**: Avoid specs with high failure rates that waste resources
+
+
+        **Response Details:**
+
+        - `failureCount`: Total number of provisioning failures
+
+        - `successCount`: Number of successes (only tracked after failures occur)
+
+        - `failureImages`: List of CSP images that failed with this spec
+
+        - `successImages`: List of CSP images that succeeded with this spec
+
+        - `failureMessages`: Detailed error messages from CSP
+
+        - `lastUpdated`: Timestamp of most recent provisioning attempt'
+    GetPublicKeyForCredentialEncryption:
+      method: get
+      resourcePath: /credential/publicKey
+      description: Generates an RSA key pair using a 4096-bit key size with the RSA algorithm. The public key is generated using the RSA algorithm with OAEP padding and SHA-256 as the hash function. This key is used to encrypt an AES key that will be used for hybrid encryption of credentials.
+    GetReadyz:
       method: get
       resourcePath: /readyz
-      description: "Check Tumblebug is ready"
-    Setbastionnodes:
-      method: put
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion/{bastionVmId}
-      description: "Set bastion nodes for a VM"
-    Postmcidynamic:
+      description: Check Tumblebug is ready. Returns ready status and initialization status.
+    GetRegion:
+      method: get
+      resourcePath: /provider/{providerName}/region/{regionName}
+      description: Get registered region info
+    GetRegions:
+      method: get
+      resourcePath: /provider/{providerName}/region
+      description: Get registered region info
+    GetRequest:
+      method: get
+      resourcePath: /request/{reqId}
+      description: Get details of a specific request
+    GetRequestStatusOfSiteToSiteVpn:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn/{vpnId}/request/{requestId}
+      description: Check the status of a specific request by its ID
+    GetRequiredK8sSubnetCount:
+      method: get
+      resourcePath: /requiredK8sSubnetCount
+      description: Get the required subnet count to create a K8sCluster
+    GetResourcesByLabelSelector:
+      method: get
+      resourcePath: /resources/{labelType}
+      description: 'Get resources based on a label selector. The label selector supports the following operators:
+
+        - `=` : Selects resources where the label key equals the specified value (e.g., `env=production`).
+
+        - `!=` : Selects resources where the label key does not equal the specified value (e.g., `tier!=frontend`).
+
+        - `in` : Selects resources where the label key is in the specified set of values (e.g., `region in (us-west, us-east)`).
+
+        - `notin` : Selects resources where the label key is not in the specified set of values (e.g., `env notin (production, staging)`).
+
+        - `exists` : Selects resources where the label key exists (e.g., `env exists`).
+
+        - `!exists` : Selects resources where the label key does not exist (e.g., `env !exists`).'
+    GetScheduleRegisterCspResourcesList:
+      method: get
+      resourcePath: /registerCspResources/schedule
+      description: Get a list of all scheduled CSP resource registration jobs (jobs are not scoped to namespaces)
+    GetScheduleRegisterCspResourcesStatus:
+      method: get
+      resourcePath: /registerCspResources/schedule/{jobId}
+      description: 'Get the current status of a specific scheduled CSP resource registration job
+
+
+        **Response Fields Explanation:**
+
+        - `status`: Current job state (Scheduled/Executing/Stopped)
+
+        - `enabled`: Whether job is active (can be paused with false)
+
+        - `executionCount`: Total number of executions attempted
+
+        - `successCount`: Number of successful executions
+
+        - `failureCount`: Number of failed executions
+
+        - `consecutiveFailures`: Current streak of failures (resets on success)
+
+        - `autoDisabled`: True if job was auto-disabled due to 5+ consecutive failures
+
+        - `lastExecutedAt`: Timestamp of most recent execution
+
+        - `nextExecutionAt`: Scheduled time for next execution
+
+        - `lastError`: Error message from most recent failure (empty if success)
+
+        - `lastResult`: Result message from most recent execution
+
+
+        **Monitoring Recommendations:**
+
+        - Check `consecutiveFailures` - alert if >= 3
+
+        - Monitor `autoDisabled` - requires manual intervention if true
+
+        - Compare `successCount` vs `failureCount` for reliability metrics'
+    GetSecurityGroup:
+      method: get
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: Get Security Group
+    GetSecurityGroupTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+      description: Retrieve a specific SecurityGroup Template by ID.
+    GetSiteToSiteVpn:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn/{vpnId}
+      description: Get resource info of a site-to-site VPN
+    GetSitesInInfra:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/site
+      description: Get sites in MCI
+    GetSpec:
+      method: get
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: Get spec
+    GetSqlDb:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
+      description: Get resource info of a SQL datatbase
+    GetSshKey:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: Get SSH Key
+    GetSubnet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
+      description: Get Subnet
+    GetSystemLabelInfo:
+      method: get
+      resourcePath: /labelInfo
+      description: Return LabelTypes and system defined label keys with example
+    GetVNet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+      description: Get VNet
+    GetVNetTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/vNet/{templateId}
+      description: Retrieve a specific vNet Template by ID.
+    GetVmCommandStatus:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatus/{index}
+      description: Get a specific command status record by index for a VM
+    GetVmDataDisk:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/dataDisk
+      description: Get available dataDisks for a VM
+    GetVmHandlingCommandCount:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/handlingCount
+      description: Get the number of commands currently in 'Handling' status for a specific VM. Optimized for frequent polling.
+    GetVmSshHostKey:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/sshHostKey
+      description: Get the stored SSH host key information for a specific VM. This is used for TOFU (Trust On First Use) verification.
+    InitAllConfig:
+      method: delete
+      resourcePath: /config
+      description: Init all configs
+    InitConfig:
+      method: delete
+      resourcePath: /config/{configId}
+      description: Init config
+    InspectResources:
       method: post
-      resourcePath: /ns/{nsId}/mciDynamic
-      description: "Create MCI Dynamically from common spec and image"
-    Postinfradynamicreview:
+      resourcePath: /inspectResources
+      description: Inspect Resources (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug, CB-Spider, CSP
+    InspectResourcesOverview:
+      method: get
+      resourcePath: /inspectResourcesOverview
+      description: Inspect Resources Overview (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug and CSP for all connections
+    ListDataObjects:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object
+      description: List all objects in an object storage (bucket)
+    ListObjectStorages:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage
+      description: Get the list of object storages (buckets)
+    ListObjectStoragesLagacy:
+      method: get
+      resourcePath: /resources/objectStorage
+      description: '(To be deprecated) Get the list of all object storages (buckets)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `ListAllMyBucketsResult`
+
+        - The response includes xmlns attribute: `xmlns="http://s3.amazonaws.com/doc/2006-03-01/"`
+
+        - Swagger UI may show `resource.ListAllMyBucketsResult` due to rendering limitations
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Owner>
+
+        <ID>aws-ap-northeast-2</ID>
+
+        <DisplayName>aws-ap-northeast-2</DisplayName>
+
+        </Owner>
+
+        <Buckets>
+
+        </Buckets>
+
+        </ListAllMyBucketsResult>
+
+        ```'
+    ListObjectVersions:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions
+      description: List all versions of objects in an object storage (bucket)
+    ListObjectVersionsLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/versions
+      description: '(To be deprecated) List object versions in an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `ListVersionsResult`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Name>spider-test-bucket</Name>
+
+        <Prefix></Prefix>
+
+        <KeyMarker></KeyMarker>
+
+        <VersionIdMarker></VersionIdMarker>
+
+        <NextKeyMarker></NextKeyMarker>
+
+        <NextVersionIdMarker></NextVersionIdMarker>
+
+        <MaxKeys>1000</MaxKeys>
+
+        <IsTruncated>false</IsTruncated>
+
+        <Version>
+
+        <Key>test-file.txt</Key>
+
+        <VersionId>yb4PgjnFVD2LfRZHXBjjsHBkQRHlu.TZ</VersionId>
+
+        <IsLatest>true</IsLatest>
+
+        <LastModified>2025-09-04T04:24:12Z</LastModified>
+
+        <ETag>23228a38faecd0591107818c7281cece</ETag>
+
+        <Size>23</Size>
+
+        <StorageClass>STANDARD</StorageClass>
+
+        <Owner>
+
+        <ID>aws-config01</ID>
+
+        <DisplayName>aws-config01</DisplayName>
+
+        </Owner>
+
+        </Version>
+
+        </ListVersionsResult>
+
+        ```'
+    ListVmCommandStatus:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatus
+      description: List command status records for a VM with various filtering options
+    GetAssetsSummary:
+      method: get
+      resourcePath: /assetsSummary
+      description: "Returns CSP-wise summary of specs and images in DB for a namespace,
+        including priced/unpriced spec counts. (CB-TB v0.12.6+). Used by FR-006-08
+        Setup Status > loadAssets card. query: nsId (default=system)."
+    LoadAssets:
+      method: get
+      resourcePath: /loadAssets
+      description: Load Common Resources from internal asset files (Spec, Image). By default, Azure images are excluded for faster initialization. Use includeAzure=true to fetch Azure images (may take 40+ minutes).
+    LookupImage:
+      method: post
+      resourcePath: /lookupImage
+      description: Lookup image (for debugging purposes)
+    LookupImageList:
+      method: post
+      resourcePath: /lookupImages
+      description: Lookup image list (for debugging purposes)
+    LookupSpec:
+      method: post
+      resourcePath: /lookupSpec
+      description: Lookup spec (for debugging purposes)
+    LookupSpecList:
+      method: post
+      resourcePath: /lookupSpecs
+      description: Lookup spec list (for debugging purposes)
+    MergeCSPResourceLabel:
+      method: put
+      resourcePath: /mergeCSPLabel/{labelType}/{uid}
+      description: Fetch the labels in the CSP and merge them with the existing labels
+    PostBuildAgnosticImage:
+      method: post
+      resourcePath: /ns/{nsId}/buildAgnosticImage
+      description: Creates an MCI infrastructure, executes post-deployment commands, creates snapshots from each subgroup, and optionally cleans up the MCI. This is a complete workflow for building CSP-agnostic custom images.
+    PostCmdK8sCluster:
+      method: post
+      resourcePath: /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}
+      description: 'Send a command to specified Container in K8sCluster
+
+        [note] This feature is not intended for general use
+
+        This API is provided as an exceptional and limited function for specific purposes such as migration.
+
+        Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.'
+    PostCmdInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/cmd/infra/{mciId}
+      description: 'Send a command to specified MCI. Use query parameters to target specific subGroup or VM.
+
+        When async=true, returns immediately with xRequestId and streams results via SSE at GET /stream/ns/{nsId}/cmd/mci/{mciId}?xRequestId={xRequestId}'
+    PostConfig:
+      method: post
+      resourcePath: /config
+      description: Create or Update config (TB_SPIDER_REST_URL, TB_DRAGONFLY_REST_URL, ...)
+    PostCustomImage:
+      method: post
+      resourcePath: /ns/{nsId}/resources/customImage
+      description: Register existing Custom Image in a CSP (option=register)
+    PostDataDisk:
+      method: post
+      resourcePath: /ns/{nsId}/resources/dataDisk
+      description: Create Data Disk
+    PostDownloadFileFromInfraNode:
+
+      method: post
+      resourcePath: /ns/{nsId}/downloadFile/infra/{mciId}/node/{vmId}
+      description: 'Download a file from a specific VM in MCI via SCP through bastion host.
+
+        The file size should be less than 200MB.'
+    PostFileToK8sCluster:
+      method: post
+      resourcePath: /ns/{nsId}/transferFile/k8sCluster/{k8sClusterId}
+      description: 'Transfer a file to specified Container in K8sCluster. The tar command is required in the container.
+
+        [note] This feature is not intended for general use
+
+        This API is provided as an exceptional and limited function for specific purposes such as migration.
+
+        Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.'
+    PostFileToInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/transferFile/infra/{mciId}
+      description: 'Transfer a file to specified MCI to the specified path.
+
+        The file size should be less than 10MB.
+
+        Not for gerneral file transfer but for specific purpose (small configuration files).'
+    PostFirewallRules:
+      method: post
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
+      description: 'Add new FirewallRules: Add the provided firewall rules to the existing rules in the Security Group.
+
+        This API will only add new rules without deleting or modifying existing ones.
+
+        If a rule with identical properties already exists, it will be skipped to avoid duplicates.
+
+
+        Usage:
+
+        Use this API to add new firewall rules to a Security Group while preserving existing rules.
+
+        - Only new rules that don''t already exist will be added.
+
+        - Existing rules remain unchanged.
+
+        - If an identical rule already exists, it will be skipped.
+
+
+        Notes:
+
+        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+
+        - The valid port number range is 0 to 65535 (inclusive).
+
+        - "Protocol" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).
+
+        - "Direction" must be either "inbound" or "outbound".
+
+        - "CIDR" is the allowed IP range.'
+    PostImage:
+      method: post
+      resourcePath: /ns/{nsId}/resources/image
+      description: Register image
+    PostInstallBenchmarkAgentToInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/installBenchmarkAgent/infra/{mciId}
+      description: Install the benchmark agent to specified MCI
+    PostInstallMonitorAgentToInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/monitoring/install/infra/{mciId}
+      description: Install monitoring agent (CB-Dragonfly agent) to MCI
+    PostK8sCluster:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster
+      description: Create K8sCluster<br>Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1614
+    PostK8sClusterDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/k8sClusterDynamic
+      description: Create K8sCluster Dynamically from common spec and image
+    PostK8sClusterDynamicCheckRequest:
+      method: post
+      resourcePath: /k8sClusterDynamicCheckRequest
+      description: Check available ConnectionConfig list before create K8sCluster Dynamically from common spec and image
+    PostK8sMultiClusterDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/k8sMultiClusterDynamic
+      description: '(PoC API. For developers only, and do not use in production.)
+
+        Create multiple K8sClusters in parallel from common spec and image.
+
+        If namePrefix is provided, cluster names will be auto-generated as ''{namePrefix}-{csp}-{number}'' (e.g., ''across-aws-1'', ''across-alibaba-2'').
+
+
+        If namePrefix is not provided, each cluster must have a name specified.
+
+
+        **Example request body:**
+
+        ```json
+
+        {
+
+        "namePrefix": "across",
+
+        "clusters": [
+
+        {
+
+        "imageId": "default",
+
+        "specId": "aws+eu-west-2+t3a.xlarge"
+
+        },
+
+        {
+
+        "nodeGroupName": "ng-1",
+
+        "imageId": "default",
+
+        "specId": "azure+germanywestcentral+standard_b4ms"
+
+        },
+
+        {
+
+        "nodeGroupName": "ng-1",
+
+        "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2204-jammy-v20251120",
+
+        "specId": "gcp+europe-west9+e2-highmem-4"
+
+        }
+
+        ]
+
+        }
+
+        ```'
+    PostK8sNodeGroup:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup
+      description: Add a K8sNodeGroup
+    PostK8sNodeGroupDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroupDynamic
+      description: Create K8sNodeGroup Dynamically from common spec and image
+    PostMcNLB:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/mcSwNlb
+      description: Create a special purpose MCI for NLB and depoly and setting SW NLB
+    PostInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra
+      description: 'Create MCI with detailed VM specifications and resource configuration.
+
+        This endpoint creates a complete multi-cloud infrastructure by:
+
+        1. **VM Provisioning**: Creates VMs across multiple cloud providers using predefined specs and images
+
+        2. **Resource Management**: Automatically handles VPC/VNet, security groups, SSH keys, and network configuration
+
+        3. **Status Tracking**: Monitors VM creation progress and handles failures based on policy settings
+
+        4. **Post-Deployment**: Optionally installs monitoring agents and executes custom commands
+
+
+        **Key Features:**
+
+        - Multi-cloud VM deployment with heterogeneous configurations
+
+        - Automatic resource dependency management (VPC → Security Group → VM)
+
+        - Built-in failure handling with configurable policies (continue/rollback/refine)
+
+        - Optional CB-Dragonfly monitoring agent installation
+
+        - Post-deployment command execution support
+
+        - Real-time status updates and progress tracking
+
+
+        **VM Lifecycle:**
+
+        1. Creating → Running (successful deployment)
+
+        2. Creating → Failed (deployment error, handled by failure policy)
+
+        3. Running → Terminated (manual or policy-driven cleanup)
+
+
+        **Failure Policies:**
+
+        - `continue`: Keep successful VMs, mark failed ones for later refinement
+
+        - `rollback`: Delete entire MCI if any VM fails (all-or-nothing)
+
+        - `refine`: Automatically clean up failed VMs, keep successful ones
+
+
+        **Resource Requirements:**
+
+        - Valid VM specifications (must exist in system namespace)
+
+        - Valid images (must be available in target CSP regions)
+
+        - Sufficient CSP quotas and permissions
+
+        - Network connectivity between components'
+    PostInfraDynamic:
+
+      method: post
+      resourcePath: /ns/{nsId}/infraDynamic
+      description: 'Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.
+
+        This is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:
+
+
+        **Dynamic Resource Creation:**
+
+        1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace
+
+        2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider
+
+        3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously
+
+        4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically
+
+        5. **Failure Recovery**: Implements configurable failure policies for robust deployment
+
+
+        **Key Advantages Over Static MCI:**
+
+        - **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources
+
+        - **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys
+
+        - **Multi-Cloud Optimization**: Intelligent placement and configuration across providers
+
+        - **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically
+
+        - **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization
+
+
+        **Configuration Process:**
+
+        1. **Resource Discovery**: Use `/recommendSpec` to find suitable VM specifications
+
+        2. **Image Selection**: Use system namespace to discover compatible images
+
+        3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment
+
+        4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration
+
+        5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options
+
+
+        **Failure Policies (PolicyOnPartialFailure):**
+
+        - **`continue`** (default): Create MCI with successful VMs, failed VMs remain for manual refinement
+
+        - **`rollback`**: Delete entire MCI if any VM fails (all-or-nothing deployment)
+
+        - **`refine`**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)
+
+
+        **Deployment Options:**
+
+        - **`hold`**: Create MCI object but hold VM provisioning for manual approval
+
+        - **Normal**: Proceed with immediate VM provisioning after resource creation
+
+
+        **Multi-Cloud Example Configuration:**
+
+        ```json
+
+        {
+
+        "name": "multi-cloud-web-tier",
+
+        "description": "Web application across AWS, Azure, and GCP",
+
+        "policyOnPartialFailure": "refine",
+
+        "vm": [
+
+        {
+
+        "name": "aws-web-servers",
+
+        "subGroupSize": "3",
+
+        "specId": "aws+us-east-1+t3.medium",
+
+        "imageId": "ami-0abcdef1234567890",
+
+        "rootDiskSize": "100",
+
+        "label": {"tier": "web", "provider": "aws"}
+
+        },
+
+        {
+
+        "name": "azure-api-servers",
+
+        "subGroupSize": "2",
+
+        "specId": "azure+eastus+Standard_B2s",
+
+        "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts",
+
+        "label": {"tier": "api", "provider": "azure"}
+
+        }
+
+        ]
+
+        }
+
+        ```
+
+
+        **Performance Considerations:**
+
+        - VM provisioning occurs in parallel across providers
+
+        - Network resources are created concurrently where possible
+
+        - Large deployments (>10 VMs) automatically use optimized batching
+
+        - Built-in rate limiting prevents CSP API throttling
+
+
+        **Monitoring and Post-Deployment:**
+
+        - Optional CB-Dragonfly monitoring agent installation
+
+        - Custom post-deployment command execution
+
+        - Real-time status tracking and progress updates
+
+        - Automatic resource labeling and metadata management'
+    PostInfraDynamicCheckRequest:
+
+      method: post
+      resourcePath: /infraDynamicCheckRequest
+      description: '**⚠️ DEPRECATED: This endpoint is deprecated and will be removed in a future version. Please use `/mciDynamicReview` instead for comprehensive validation and cost estimation.**
+
+
+        Validate resource availability and discover optimal connection configurations before creating MCI dynamically.
+
+        This endpoint provides comprehensive resource validation and connection discovery for MCI planning:
+
+
+        **Resource Validation Process:**
+
+        1. **Specification Analysis**: Validates that requested common specs exist and are accessible
+
+        2. **Provider Discovery**: Identifies available cloud providers and regions for each specification
+
+        3. **Connectivity Assessment**: Tests connection configurations and CSP API accessibility
+
+        4. **Quota Verification**: Checks available quotas and resource limits where possible
+
+        5. **Compatibility Matrix**: Generates matrix of viable spec-provider-region combinations
+
+
+        **Connection Configuration Discovery:**
+
+        - **Available Providers**: Lists all configured cloud providers (AWS, Azure, GCP, etc.)
+
+        - **Active Regions**: Shows available regions per provider with connectivity status
+
+        - **Specification Mapping**: Maps common specs to provider-specific instance types
+
+        - **Image Compatibility**: Validates image availability across different providers/regions
+
+        - **Network Capabilities**: Identifies supported network features and configurations
+
+
+        **Pre-Deployment Validation:**
+
+        - **Resource Existence**: Confirms all specified resources exist in system namespace
+
+        - **Permission Verification**: Validates CSP credentials and required permissions
+
+        - **API Connectivity**: Tests connection to CSP APIs and service endpoints
+
+        - **Dependency Resolution**: Identifies any missing dependencies or prerequisites
+
+
+        **Optimization Recommendations:**
+
+        - **Cost-Effective Regions**: Suggests regions with lower pricing for specified resources
+
+        - **Performance Optimization**: Recommends regions with better network performance
+
+        - **Availability Zone**: Identifies optimal AZ distribution for high availability
+
+        - **Resource Bundling**: Suggests efficient resource combinations and groupings
+
+
+        **Output Information:**
+
+        - **Connection Candidates**: List of viable connection configurations
+
+        - **Provider Capabilities**: Detailed capabilities matrix per provider
+
+        - **Resource Status**: Real-time availability status for each requested resource
+
+        - **Recommendation Summary**: Actionable recommendations for optimal deployment
+
+
+        **Use Cases:**
+
+        - Pre-validate MCI configuration before expensive deployment operations
+
+        - Discover optimal provider/region combinations for cost or performance
+
+        - Troubleshoot resource availability issues during MCI planning
+
+        - Generate connection configuration templates for standardized deployments
+
+        - Assess infrastructure capacity and planning constraints
+
+
+        **Integration Workflow:**
+
+        1. Use this endpoint to validate and discover connection options
+
+        2. Review recommendations and adjust specifications if needed
+
+        3. Use `/mciDynamicReview` for detailed cost estimation and final validation
+
+        4. Proceed with `/mciDynamic` using validated configuration'
+    PostInfraDynamicFromTemplate:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/template/{templateId}
+      description: 'Create a new MCI by applying an MCI Dynamic Template.
+
+        The template provides the base VM configuration, and the apply request
+
+        allows overriding the MCI name and description.
+
+
+        **Override Behavior (Phase 1):**
+
+        - `name` (required): Name for the new MCI
+
+        - `description` (optional): Overrides the template''s description
+
+        - All other configuration (specs, images, subgroups) comes from the template'
+    PostInfraDynamicReview:
+
       method: post
       resourcePath: /ns/{nsId}/infraDynamicReview
-      description: "Review and validate Infra dynamic request comprehensively before actual provisioning"
+      description: 'Review and validate MCI dynamic request comprehensively before actual provisioning.
+
+        This endpoint performs comprehensive validation of MCI dynamic creation requests without actually creating resources.
+
+        It checks resource availability, validates specifications and images, estimates costs, and provides detailed recommendations.
+
+
+        **Key Features:**
+
+        - Validates all VM specifications and images against CSP availability
+
+        - Provides cost estimation (including partial estimates when some costs are unknown)
+
+        - Identifies potential configuration issues and warnings
+
+        - Recommends optimization strategies
+
+        - Shows provider and region distribution
+
+        - Non-invasive validation (no resources are created)
+
+
+        **Review Status:**
+
+        - `Ready`: All VMs can be created successfully
+
+        - `Warning`: VMs can be created but with configuration warnings
+
+        - `Error`: Critical errors prevent MCI creation
+
+
+        **Use Cases:**
+
+        - Pre-validation before expensive MCI creation
+
+        - Cost estimation and planning
+
+        - Configuration optimization
+
+        - Multi-cloud resource planning'
+    PostInfraDynamicNodeGroupNodeReview:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodeGroupDynamicReview
+      description: 'Review and validate a VM dynamic addition request for an existing MCI before actual provisioning.
+
+        This endpoint provides comprehensive validation for adding new VMs to existing MCIs without actually creating resources.
+
+        It checks resource availability, validates specifications and images, estimates costs, and provides detailed recommendations.
+
+
+        **Key Features:**
+
+        - Validates VM specification and image against CSP availability
+
+        - Checks compatibility with existing MCI configuration
+
+        - Provides cost estimation for the new VM addition
+
+        - Identifies potential configuration issues and warnings
+
+        - Recommends optimization strategies
+
+        - Non-invasive validation (no resources are created)
+
+
+        **Review Status:**
+
+        - `Ready`: VM can be added successfully
+
+        - `Warning`: VM can be added but with configuration warnings
+
+        - `Error`: Critical errors prevent VM addition
+
+
+        **MCI Integration Validation:**
+
+        - Ensures target MCI exists and is in a compatible state
+
+        - Validates network integration possibilities
+
+        - Checks resource naming conflicts
+
+        - Verifies security group and SSH key compatibility
+
+
+        **Use Cases:**
+
+        - Pre-validation before expensive VM addition operations
+
+        - Cost estimation for scaling decisions
+
+        - Configuration optimization before deployment
+
+        - Risk assessment for VM addition to existing infrastructure'
+    PostInfraDynamicTemplate:
+
+      method: post
+      resourcePath: /ns/{nsId}/template/infra
+      description: 'Create a reusable MCI Dynamic Template. Templates store MCI dynamic creation
+
+        request configurations that can be applied later to create MCIs with consistent settings.
+
+
+        **Template Contents:**
+
+        - VM specifications (specId, imageId) for each subgroup
+
+        - Subgroup sizing and naming
+
+        - Network and disk configuration
+
+        - Post-deployment commands
+
+        - Monitoring agent options
+
+
+        Templates can be created manually or extracted from existing MCIs.'
+    PostInfraPolicy:
+
+      method: post
+      resourcePath: /ns/{nsId}/policy/infra/{mciId}
+      description: Create MCI Automation policy
+    PostInfraSnapshot:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/snapshot
+      description: Create snapshots for the first running VM in each subgroup of an MCI in parallel
+    PostInfraNodeGroupDynamic:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodeGroupDynamic
+      description: 'Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management.
+
+        This endpoint provides elastic scaling capabilities for running MCIs:
+
+
+        **Dynamic VM Addition Process:**
+
+        1. **MCI Validation**: Verifies target MCI exists and is in a valid state for expansion
+
+        2. **Resource Discovery**: Resolves common spec and image to provider-specific resources
+
+        3. **Network Integration**: Automatically configures new VMs to use existing MCI network resources
+
+        4. **Subgroup Management**: Creates new subgroups or expands existing ones based on configuration
+
+        5. **Status Synchronization**: Updates MCI status and metadata to reflect new VM additions
+
+
+        **Integration with Existing Infrastructure:**
+
+        - **Network Reuse**: New VMs automatically join existing VNets and security groups
+
+        - **SSH Key Sharing**: Uses existing SSH keys for consistent access management
+
+        - **Monitoring Integration**: New VMs inherit monitoring configuration from parent MCI
+
+        - **Label Propagation**: Applies MCI-level labels and policies to new VMs
+
+        - **Resource Consistency**: Maintains naming conventions and resource organization
+
+
+        **Scaling Scenarios:**
+
+        - **Horizontal Scaling**: Add more instances to handle increased workload
+
+        - **Multi-Region Expansion**: Deploy VMs in new regions while maintaining MCI cohesion
+
+        - **Provider Diversification**: Add VMs from different cloud providers for redundancy
+
+        - **Workload Specialization**: Deploy VMs with different specifications for specific tasks
+
+
+        **Configuration Requirements:**
+
+        - `specId`: Must specify valid VM specification from system namespace
+
+        - `imageId`: Must specify valid image compatible with target provider/region
+
+        - `name`: Becomes subgroup name; VMs will be named with sequential suffixes
+
+        - `subGroupSize`: Number of identical VMs to create (default: 1)
+
+
+        **Network and Security:**
+
+        - New VMs automatically inherit security group rules from existing MCI
+
+        - Network connectivity to existing VMs is established automatically
+
+        - Firewall rules and access policies are applied consistently
+
+        - SSH access is configured using existing key pairs
+
+
+        **Example Use Cases:**
+
+        - Scale out web tier during traffic spikes
+
+        - Add GPU instances for machine learning workloads
+
+        - Deploy edge nodes in additional geographic regions
+
+        - Add specialized storage or database nodes to existing application stack
+
+
+        **Post-Addition Operations:**
+
+        - New VMs are immediately available for standard MCI operations
+
+        - Can be individually managed or grouped with existing subgroups
+
+        - Monitoring and logging are automatically configured
+
+        - Application deployment and configuration management can proceed immediately'
+    PostInfraNodeGroupScaleOut:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodegroup/{subgroupId}
+      description: 'Horizontally scale an existing VM subgroup by adding more identical instances for increased capacity.
+
+        This endpoint provides elastic scaling capabilities for running application tiers:
+
+
+        **Scale-Out Process:**
+
+        1. **SubGroup Validation**: Verifies target subgroup exists and is in scalable state
+
+        2. **Template Replication**: Uses existing VM configuration as template for new instances
+
+        3. **Resource Allocation**: Ensures sufficient CSP quotas and network resources
+
+        4. **Parallel Deployment**: Deploys multiple new VMs simultaneously for faster scaling
+
+        5. **Integration**: Seamlessly integrates new VMs into existing subgroup and MCI
+
+
+        **Configuration Inheritance:**
+
+        - **VM Specifications**: New VMs inherit exact specifications from existing subgroup members
+
+        - **Network Settings**: Automatically placed in same VNet, subnet, and security groups
+
+        - **SSH Keys**: Use same SSH key pairs for consistent access management
+
+        - **Monitoring**: Inherit monitoring agent configuration and policies
+
+        - **Labels and Metadata**: Propagate all labels and metadata from parent subgroup
+
+
+        **Scaling Scenarios:**
+
+        - **Traffic Spikes**: Quickly add capacity during high-demand periods
+
+        - **Seasonal Scaling**: Scale out for predictable demand increases
+
+        - **Performance Optimization**: Add instances to reduce per-VM resource utilization
+
+        - **Geographic Expansion**: Scale existing workloads to handle broader user base
+
+        - **Fault Tolerance**: Increase redundancy by adding more instances
+
+
+        **Intelligent Scaling:**
+
+        - **Sequential Naming**: New VMs follow established naming pattern (e.g., web-4, web-5, web-6)
+
+        - **Load Distribution**: New VMs are distributed optimally across availability zones
+
+        - **Resource Efficiency**: Reuses existing network and security infrastructure
+
+        - **Minimal Disruption**: Scaling occurs without affecting existing VM operations
+
+        - **Consistent Configuration**: Ensures all VMs in subgroup remain homogeneous
+
+
+        **Operational Benefits:**
+
+        - **Zero Downtime**: Existing VMs continue running during scale-out operation
+
+        - **Immediate Availability**: New VMs are ready for traffic as soon as deployment completes
+
+        - **Unified Management**: All VMs (old and new) managed through single subgroup
+
+        - **Policy Consistency**: All scaling and management policies apply uniformly
+
+        - **Monitoring Integration**: New VMs automatically included in existing monitoring dashboards
+
+
+        **Scale-Out Considerations:**
+
+        - **CSP Quotas**: Verifies sufficient instance, network, and storage quotas
+
+        - **Region Capacity**: Ensures target region has capacity for requested instance types
+
+        - **Network Limits**: Validates that VNet can accommodate additional VMs
+
+        - **Cost Impact**: Additional VMs incur proportional CSP billing costs
+
+        - **Application Readiness**: Applications should be designed to handle additional instances
+
+
+        **Post-Scale Operations:**
+
+        - New VMs immediately participate in subgroup operations
+
+        - Can be individually managed while maintaining subgroup membership
+
+        - Support for further scaling operations (scale-out or scale-in)
+
+        - Ready for application deployment and load balancer integration
+
+
+        **Best Practices:**
+
+        - Monitor application performance before and after scaling
+
+        - Ensure load balancers are configured to include new instances
+
+        - Verify application clustering and session management handle new instances
+
+        - Consider database connection limits and other resource constraints'
+    PostInfraNode:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/node
+      description: 'Create and add a group of identical virtual machines (subgroup) to an existing MCI using detailed specifications.
+
+        This endpoint provides precise control over VM configuration and placement within existing infrastructure:
+
+
+        **SubGroup Creation Process:**
+
+        1. **MCI Integration**: Validates target MCI exists and can accommodate new VMs
+
+        2. **Resource Validation**: Verifies all specified resources (specs, images, networks) exist and are accessible
+
+        3. **Homogeneous Deployment**: Creates multiple identical VMs with consistent configuration
+
+        4. **Network Integration**: Integrates new VMs with existing MCI networking and security policies
+
+        5. **Group Management**: Establishes subgroup for collective management and operations
+
+
+        **Detailed Configuration Control:**
+
+        - **Specific Resource References**: Uses exact resource IDs rather than common specifications
+
+        - **Network Placement**: Precise control over VNet, subnet, and security group assignment
+
+        - **Storage Configuration**: Detailed disk configuration including type, size, and performance tiers
+
+        - **Instance Customization**: Full control over VM specifications, images, and metadata
+
+        - **Security Settings**: Explicit security group and SSH key configuration
+
+
+        **SubGroup Benefits:**
+
+        - **Collective Operations**: Perform operations on entire subgroup simultaneously
+
+        - **Homogeneous Scaling**: All VMs in subgroup share identical configuration
+
+        - **Simplified Management**: Single configuration template for multiple VMs
+
+        - **Consistent Naming**: Automatic sequential naming (e.g., web-1, web-2, web-3)
+
+        - **Group Policies**: Apply scaling, monitoring, and lifecycle policies at subgroup level
+
+
+        **Use Cases:**
+
+        - **Application Tiers**: Deploy multiple instances of web servers, application servers, or databases
+
+        - **Load Distribution**: Create multiple identical VMs for load balancing scenarios
+
+        - **High Availability**: Deploy redundant instances across availability zones
+
+        - **Batch Processing**: Create worker nodes for distributed computing workloads
+
+        - **Development Environments**: Provision identical development or testing instances
+
+
+        **Configuration Requirements:**
+
+        - **Resource IDs**: Must specify exact resource identifiers (not common specs)
+
+        - **Network Configuration**: VNet, subnet, and security group must exist and be compatible
+
+        - **SSH Keys**: Must specify valid SSH key pairs for access management
+
+        - **Image Compatibility**: Specified image must be available in target region
+
+        - **Quota Validation**: Sufficient CSP quotas must be available for all requested VMs
+
+
+        **SubGroup Size Considerations:**
+
+        - **Small Groups (1-5 VMs)**: Fast deployment, minimal resource contention
+
+        - **Medium Groups (6-20 VMs)**: Optimized parallel deployment with resource batching
+
+        - **Large Groups (21+ VMs)**: Advanced deployment strategies to avoid CSP rate limits
+
+        - **Resource Limits**: Respects CSP quotas and CB-Tumblebug configuration limits
+
+
+        **Post-Deployment Integration:**
+
+        - SubGroup becomes integral part of parent MCI
+
+        - All VMs inherit MCI-level monitoring and management policies
+
+        - Can be scaled out further or individual VMs can be managed separately
+
+        - Supports all standard CB-Tumblebug VM lifecycle operations'
+    PostInfraNodeSnapshot:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/snapshot
+      description: Snapshot VM and create a Custom Image Object using the Snapshot
+    PostNLB:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb
+      description: Create NLB
+    PostNs:
+      method: post
+      resourcePath: /ns
+      description: Create namespace
+    PostRegisterCSPNativeVM:
+      method: post
+      resourcePath: /ns/{nsId}/registerCspNode
+      description: 'Import and register pre-existing virtual machines from cloud service providers into CB-Tumblebug management.
+
+        This endpoint allows you to bring existing CSP resources under CB-Tumblebug control without recreating them:
+
+
+        **Registration Process:**
+
+        1. **Discovery**: Validates that the specified VM exists in the target CSP
+
+        2. **Metadata Import**: Retrieves VM configuration, network settings, and current status
+
+        3. **Resource Mapping**: Creates CB-Tumblebug resource objects that reference the existing CSP resources
+
+        4. **Status Synchronization**: Aligns CB-Tumblebug status with actual CSP VM state
+
+        5. **Management Integration**: Enables CB-Tumblebug operations on the registered VMs
+
+
+        **Supported VM States:**
+
+        - Running VMs (most common use case)
+
+        - Stopped VMs (will be registered with current state)
+
+        - VMs with attached storage and network interfaces
+
+
+        **Resource Compatibility:**
+
+        - VM must exist in a supported CSP (AWS, Azure, GCP, etc.)
+
+        - Network resources (VPC, subnets, security groups) will be discovered and mapped
+
+        - Storage volumes and attached disks will be registered automatically
+
+        - SSH keys and security configurations will be imported
+
+
+        **Post-Registration Capabilities:**
+
+        - Standard CB-Tumblebug VM lifecycle operations (start, stop, terminate)
+
+        - Monitoring agent installation (if CB-Dragonfly is configured)
+
+        - Command execution and automation
+
+        - Integration with other CB-Tumblebug MCIs
+
+
+        **Important Notes:**
+
+        - Registration does not modify the existing VM configuration
+
+        - Original CSP billing and resource management still applies
+
+        - CB-Tumblebug provides additional management layer and automation
+
+        - Ensure proper CSP credentials and permissions are configured'
+    PostRegisterSubnet:
+      method: post
+      resourcePath: /ns/{nsId}/registerCspResource/vNet/{vNetId}/subnet
+      description: Register Subnet, which was created in CSP
+    PostRegisterVNet:
+      method: post
+      resourcePath: /ns/{nsId}/registerCspResource/vNet
+      description: Register the VNet, which was created in CSP
+    PostScheduleRegisterCspResources:
+      method: post
+      resourcePath: /registerCspResources/schedule
+      description: 'Create a scheduled job to periodically register CSP-native resources (vNet, securityGroup, sshKey, vm) into CB-Tumblebug
+
+
+        **Resource Registration Behavior:**
+
+        This job registers CSP-native resources based on the `connectionName` field:
+
+        - If `connectionName` is specified: Registers resources from the **specified connection only**
+
+        - If `connectionName` is empty or omitted: Registers resources from **all available connections**
+
+
+        **Usage Examples:**
+
+        - Single connection: `{"jobType": "registerCspResources", "nsId": "default", "intervalSeconds": 60, "connectionName": "aws-ap-northeast-2", "mciNamePrefix": "mci-01"}`
+
+        - All connections: `{"jobType": "registerCspResources", "nsId": "default", "intervalSeconds": 60, "connectionName": "", "mciNamePrefix": "mci-all"}` or `{"jobType": "registerCspResources", "nsId": "default", "intervalSeconds": 60, "mciNamePrefix": "mci-all"}`
+
+
+        **Job Status Values:**
+
+        - `Scheduled`: Job is scheduled and waiting for the next execution time
+
+        - `Executing`: Job is currently running the task
+
+        - `Stopped`: Job has been stopped and deleted
+
+
+        **Job Lifecycle:**
+
+        1. Create job (this API) → Status: `Scheduled`, **executes immediately**
+
+        2. First execution starts → Status: `Executing`
+
+        3. Execution completes → Status: `Scheduled` (waits for interval)
+
+        4. After interval → Status: `Executing` (cycles back to step 3)
+
+        5. Pause job → `enabled: false`, Status: `Scheduled` (no execution)
+
+        6. Resume job → `enabled: true`, Status: `Scheduled` (resumes execution)
+
+        7. Delete job → Status: `Stopped`, job removed permanently
+
+
+        **Failure Handling:**
+
+        - Tracks `successCount`, `failureCount`, `consecutiveFailures`
+
+        - Auto-disables after 5 consecutive failures (`autoDisabled: true`)
+
+        - Auto-recovers when next execution succeeds
+
+
+        **Timeout Protection:**
+
+        - Default execution timeout: 30 minutes
+
+        - Jobs exceeding timeout are marked as failed
+
+        - Server restart during execution marks job as interrupted
+
+
+        **Duplicate Prevention:**
+
+        - System checks for existing jobs with same configuration
+
+        - Configuration uniqueness based on: jobType + nsId + connectionName + mciNamePrefix + option + mciFlag
+
+        - Returns 409 Conflict if duplicate job exists with existing job ID'
+    PostSecurityGroup:
+      method: post
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: Create Security Group
+    PostSecurityGroupFromTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/resources/securityGroup/template/{templateId}
+      description: 'Create a new SecurityGroup by applying a SecurityGroup Template.
+
+        The template provides the base SecurityGroup configuration (connectionName, vNetId, firewallRules),
+
+        and the apply request allows overriding the SecurityGroup name and description.
+
+
+        **Override Behavior (Phase 1):**
+
+        - `name` (required): Name for the new SecurityGroup
+
+        - `description` (optional): Overrides the template''s description
+
+        - All other configuration (connectionName, vNetId, firewallRules) comes from the template'
+    PostSecurityGroupTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/template/securityGroup
+      description: 'Create a reusable SecurityGroup Template. Templates store SecurityGroup creation
+
+        request configurations that can be applied later to create SecurityGroups with consistent settings.
+
+
+        **Template Contents:**
+
+        - Connection name (cloud provider and region)
+
+        - vNet ID for the security group
+
+        - Firewall rules (ports, protocol, direction, CIDR)
+
+        - Description
+
+
+        Templates can be created manually with desired SecurityGroup configurations.'
+    PostSiteToSiteVpn:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn
+      description: 'Create a site-to-site VPN
+
+
+        The supported CSP sets are as follows:
+
+
+        - AWS and one of CSPs in Azure, GCP, Alibaba, Tencent, and IBM
+
+
+        - Note: It will take about `15 ~ 45 minutes`.
+
+
+        - Note: A one-time retry is performed to handle transient failures caused by CSP-internal timing issues between dependent resources.
+
+        '
+    PostSpec:
+      method: post
+      resourcePath: /ns/{nsId}/resources/spec
+      description: Register spec
+    PostSpecImagePairReview:
+      method: post
+      resourcePath: /specImagePairReview
+      description: 'Validate whether a spec and image pair is compatible for VM provisioning.
+
+        This lightweight API checks:
+
+        - Spec availability in DB and CSP
+
+        - Image availability in DB and CSP (auto-registers if found in CSP but not in DB)
+
+        - Cost estimation based on spec
+
+
+        **Use Cases:**
+
+        - Quick validation before VM creation
+
+        - Pre-check for dynamic provisioning
+
+        - Verify custom image IDs entered by user'
+    PostSqlDb:
+      method: post
+      resourcePath: /ns/{nsId}/resources/sqlDb
+      description: 'Create a SQL Databases
+
+
+        Supported CSPs: AWS, Azure, GCP, NCP
+
+        - Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral, gcp-asia-northeast3, ncp-kr
+
+
+        - Note - Please check the `requiredCSPResource` property which includes CSP specific values.
+
+
+        - Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/110
+
+        '
+    PostSshKey:
+      method: post
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: Create SSH Key
+    PostSubnet:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
+      description: Create Subnet
+    PostSystemInfra:
+
+      method: post
+      resourcePath: /systemInfra
+      description: 'Create specialized MCI instances for CB-Tumblebug system operations and infrastructure probing.
+
+        This endpoint provisions system-level infrastructure that supports CB-Tumblebug''s internal functions:
+
+
+        **System MCI Types:**
+
+        - `probe`: Creates lightweight VMs for network connectivity testing and CSP capability discovery
+
+        - `monitor`: Deploys monitoring infrastructure for system health and performance tracking
+
+        - `test`: Provisions test environments for validating CSP integrations and features
+
+
+        **Probe MCI Features:**
+
+        - **Connectivity Testing**: Validates network paths between different CSP regions
+
+        - **Latency Measurement**: Measures inter-region and inter-provider network performance
+
+        - **Feature Discovery**: Tests CSP-specific capabilities and service availability
+
+        - **Resource Validation**: Verifies that CB-Tumblebug can successfully provision resources
+
+
+        **System Namespace:**
+
+        - All system MCIs are created in the special `system` namespace
+
+        - Isolated from user workloads and regular MCI operations
+
+        - Managed automatically by CB-Tumblebug internal processes
+
+        - May be used for background maintenance and monitoring tasks
+
+
+        **Automatic Configuration:**
+
+        - Uses optimized VM specifications for system tasks (typically minimal resources)
+
+        - Automatically selects appropriate regions and providers based on probe requirements
+
+        - Configures necessary network access and security policies
+
+        - Deploys with minimal attack surface and security hardening
+
+
+        **Lifecycle Management:**
+
+        - System MCIs may be automatically created, updated, or destroyed by CB-Tumblebug
+
+        - Typically short-lived for specific system tasks
+
+        - Resource cleanup is handled automatically
+
+        - Status and results are logged for system administrators
+
+
+        **Use Cases:**
+
+        - Infrastructure health checks and validation
+
+        - Performance benchmarking across cloud providers
+
+        - Automated testing of new CSP integrations
+
+        - Network topology discovery and optimization'
+    PostTestStreamResponse:
+      method: post
+      resourcePath: /testStreamResponse
+      description: Receives a number and streams the decrementing number every second until zero
+    PostUtilToDesignNetwork:
+      method: post
+      resourcePath: /util/net/design
+      description: Design a hierarchical network configuration of a VPC network or multi-cloud network consisting of multiple VPC networks
+    PostUtilToDesignVNet:
+      method: post
+      resourcePath: /util/vNet/design
+      description: Design VNet and subnets based on user-friendly properties
+    PostUtilToValidateNetwork:
+      method: post
+      resourcePath: /util/net/validate
+      description: Validate a hierarchical configuration of a VPC network or multi-cloud network consisting of multiple VPC networks
+    PostVNet:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: Create a new VNet
+    PostVNetFromTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet/template/{templateId}
+      description: 'Create a new vNet by applying a vNet Template.
+
+        The template provides the base vNet configuration (connectionName, cidrBlock, subnets),
+
+        and the apply request allows overriding the vNet name and description.
+
+
+        **Override Behavior (Phase 1):**
+
+        - `name` (required): Name for the new vNet
+
+        - `description` (optional): Overrides the template''s description
+
+        - All other configuration (connectionName, cidrBlock, subnets) comes from the template'
+    PostVNetTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/template/vNet
+      description: 'Create a reusable vNet Template. Templates store vNet creation
+
+        request configurations that can be applied later to create vNets with consistent settings.
+
+
+        **Template Contents:**
+
+        - Connection name (cloud provider and region)
+
+        - CIDR block configuration
+
+        - Subnet definitions (names, CIDR blocks, zones)
+
+        - Description
+
+
+        Templates can be created manually with desired vNet configurations.'
+    PostVmDataDisk:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/dataDisk
+      description: Provisioning (Create and attach) dataDisk
+    PutChangeK8sNodeGroupAutoscaleSize:
+      method: put
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize
+      description: Change a K8sNodeGroup's Autoscale Size
+    PutDataDisk:
+      method: put
+      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+      description: Upsize Data Disk
+    PutGlobalDnsRecord:
+      method: put
+      resourcePath: /resources/globalDns/record
+      description: 'Update (UPSERT) a DNS record for a domain in Route53.
+
+        Supports two routing policies: "simple" (default) and "geoproximity" (location-based).
+
+        Choose exactly one IP source method in ''setBy'':
+
+        1. MCI ID (mciId): Fetch Public IPs of all VMs in the MCI.
+
+        2. Label Selector (labelSelector): Fetch IPs of matching resources.
+
+        3. Manual IP Values (values): Manually provide IP addresses (simple routing only).'
+    PutImage:
+      method: put
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: Update image
+    PutInfraAssociatedSecurityGroups:
+
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/associatedSecurityGroups
+      description: 'Update all Security Groups associated with a given MCI. The firewall rules of all Security Groups will be synchronized to match the requested set.
+
+        Update all Security Groups associated with a given MCI. The firewall rules of all associated Security Groups will be synchronized to match the requested set.
+
+
+        This API will add missing rules and delete extra rules so that each Security Group''s rules become identical to the requested set.
+
+        Only firewall rules are updated; other metadata (name, description, etc.) is not changed.
+
+
+        Usage:
+
+        Use this API to update (synchronize) the firewall rules of all Security Groups associated with the specified MCI. The rules in the request body will become the only rules in each Security Group after the operation.
+
+        - All existing rules not present in the request will be deleted.
+
+        - All rules in the request that do not exist will be added.
+
+        - If a rule exists but differs in CIDR or port range, it will be replaced.
+
+        - Special protocols (ICMP, etc.) are handled in the same way.
+
+
+        Notes:
+
+        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+
+        - The valid port number range is 0 to 65535 (inclusive).
+
+        - "Protocol" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).
+
+        - "Direction" must be either "inbound" or "outbound".
+
+        - "CIDR" is the allowed IP range.
+
+        - All existing rules not in the request (including default ICMP, etc.) will be deleted.
+
+        - Metadata (name, description, etc.) is not changed.'
+    PutInfraDynamicTemplate:
+
+      method: put
+      resourcePath: /ns/{nsId}/template/infra/{templateId}
+      description: Update an existing MCI Dynamic Template.
+    PutMonitorAgentStatusInstalled:
+      method: put
+      resourcePath: /ns/{nsId}/monitoring/status/infra/{mciId}/node/{vmId}
+      description: Set monitoring agent (CB-Dragonfly agent) installation status installed (for Windows VM only)
+    PutNs:
+      method: put
+      resourcePath: /ns/{nsId}
+      description: Update namespace
+    PutScheduleRegisterCspResources:
+      method: put
+      resourcePath: /registerCspResources/schedule/{jobId}
+      description: 'Update the configuration of a scheduled CSP resource registration job (interval, enabled status)
+
+
+        **Updatable Fields:**
+
+        - `intervalSeconds`: Change execution frequency (minimum 10 seconds)
+
+        - `enabled`: Enable (true) or disable (false) the job
+
+
+        **Usage Examples:**
+
+        - Change interval: `{"intervalSeconds": 30}` (30 seconds)
+
+        - Pause job: `{"enabled": false}`
+
+        - Resume job: `{"enabled": true}`
+
+        - Change both: `{"intervalSeconds": 10, "enabled": true}`
+
+
+        **Note:** For simpler pause/resume operations, consider using dedicated `/pause` and `/resume` endpoints'
+    PutScheduleRegisterCspResourcesPause:
+      method: put
+      resourcePath: /registerCspResources/schedule/{jobId}/pause
+      description: 'Temporarily pause a scheduled job without deleting it. The job can be resumed later.
+
+        This sets enabled=false and preserves all job state and execution history.'
+    PutScheduleRegisterCspResourcesResume:
+      method: put
+      resourcePath: /registerCspResources/schedule/{jobId}/resume
+      description: 'Resume a previously paused scheduled job to continue periodic execution.
+
+        This sets enabled=true and restarts the job scheduler.'
+    PutSecurityGroup:
+      method: put
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: 'Update Security Group: Synchronize the firewall rules of the specified Security Group to match the requested list exactly.
+
+        This API will add missing rules and delete extra rules so that the Security Group''s rules become identical to the requested set.
+
+        Only firewall rules are updated; other metadata (name, description, etc.) is not changed.
+
+
+        Usage:
+
+        Use this API to update (synchronize) the firewall rules of a Security Group. The rules in the request body will become the only rules in the Security Group after the operation.
+
+        - All existing rules not present in the request will be deleted.
+
+        - All rules in the request that do not exist will be added.
+
+        - If a rule exists but differs in CIDR or port range, it will be replaced.
+
+        - Special protocols (ICMP, etc.) are handled in the same way.
+
+
+        Notes:
+
+        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+
+        - The valid port number range is 0 to 65535 (inclusive).
+
+        - "Protocol" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).
+
+        - "Direction" must be either "inbound" or "outbound".
+
+        - "CIDR" is the allowed IP range.
+
+        - All existing rules not in the request (including default ICMP, etc.) will be deleted.
+
+        - Metadata (name, description, etc.) is not changed.'
+    PutSecurityGroupTemplate:
+      method: put
+      resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+      description: Update an existing SecurityGroup Template.
+    PutSetK8sNodeGroupAutoscaling:
+      method: put
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoscaling
+      description: Set a K8sNodeGroup's Autoscaling On/Off
+    PutSpec:
+      method: put
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: Update spec
+    PutSshKey:
+      method: put
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: Update SSH Key
+    PutUpgradeK8sCluster:
+      method: put
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/upgrade
+      description: Upgrade a K8sCluster's version
+    PutVNetTemplate:
+      method: put
+      resourcePath: /ns/{nsId}/template/vNet/{templateId}
+      description: Update an existing vNet Template.
+    PutVmDataDisk:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/dataDisk
+      description: Attach/Detach available dataDisk
+    RecommendK8sNode:
+      method: post
+      resourcePath: /k8sClusterRecommendNode
+      description: Recommend K8sCluster's Node plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+    RecommendSpec:
+      method: post
+      resourcePath: /recommendSpec
+      description: 'Recommend specs for configuring an infrastructure (filter and priority)
+
+        Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+
+        Get available options by /recommendSpecOptions for filtering and prioritizing
+        specs in RecommendSpec API'
+      requestCoerce:
+        limit: int
+    RecommendSpecOptions:
+      method: get
+      resourcePath: /recommendSpecOptions
+      description: Get available options for filtering and prioritizing specs in RecommendSpec API
+    RecordProvisioningEvent:
+      method: post
+      resourcePath: /provisioning/event
+      description: 'Manually record a provisioning success or failure event for historical tracking and analysis.
+
+        This endpoint allows external systems or manual processes to contribute to provisioning history:
+
+
+        **Use Cases:**
+
+        - **External Provisioning Tools**: Record events from non-CB-Tumblebug provisioning systems
+
+        - **Manual Testing**: Log results from manual deployment tests
+
+        - **Migration**: Import historical data from other systems
+
+        - **Integration**: Connect with CI/CD pipelines for comprehensive tracking
+
+
+        **Event Types:**
+
+        - **Success Events**: Only recorded if previous failures exist for the spec
+
+        - **Failure Events**: Always recorded to build failure pattern database
+
+
+        **Data Quality:**
+
+        - Provide accurate timestamps for proper chronological analysis
+
+        - Include detailed error messages for failure events
+
+        - Use consistent spec ID and image name formats
+
+
+        **Impact on System:**
+
+        - Contributes to risk analysis algorithms
+
+        - Affects future MCI review recommendations
+
+        - Builds historical baseline for reliability metrics'
+    RegisterCredential:
+      method: post
+      resourcePath: /credential
+      description: This API registers credential information using hybrid encryption. The process involves compressing and encrypting sensitive data with AES-256, encrypting the AES key with a 4096-bit RSA public key (retrieved via `GET /credential/publicKey`), and using OAEP padding with SHA-256. All values, including the AES key, must be base64 encoded before sending, and the public key token ID must be included in the request.
+    RegisterCspNativeResources:
+      method: post
+      resourcePath: /registerCspResources
+      description: 'Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to CB-Tumblebug.
+
+
+        **New filtering approach (recommended):**
+
+        - Provider only: Registers resources from all connections of the specified provider
+
+        - Provider + Region: Registers resources from all zones within the region
+
+        - Provider + Region + Zone: Registers resources from specific zone
+
+        - All empty: Registers resources from **all available connections**
+
+
+        **Backward compatibility:**
+
+        - `connectionName` is still supported but deprecated. Use provider/region/zone instead.
+
+
+        **Usage Examples:**
+
+        - All AWS: `{"provider": "aws", "nsId": "default"}`
+
+        - AWS Seoul region: `{"provider": "aws", "region": "ap-northeast-2", "nsId": "default"}`
+
+        - AWS Seoul zone 2a: `{"provider": "aws", "region": "ap-northeast-2", "zone": "ap-northeast-2a", "nsId": "default"}`
+
+        - All connections: `{"nsId": "default", "mciNamePrefix": "mci-all"}`
+
+        - Single connection (deprecated): `{"connectionName": "aws-ap-northeast-2", "nsId": "default"}`'
+    RegisterCspNativeResourcesAll:
+      method: post
+      resourcePath: /registerCspResourcesAll
+      description: '**DEPRECATED**: This endpoint is deprecated. Please use `/registerCspResources` with empty `connectionName` instead.
+
+
+        This endpoint now redirects to `/registerCspResources` for unified API behavior.
+
+
+        **Migration Guide:**
+
+        - Old: `POST /registerCspResourcesAll` with `{"nsId": "default", "mciNamePrefix": "mci-all"}`
+
+        - New: `POST /registerCspResources` with `{"connectionName": "", "nsId": "default", "mciNamePrefix": "mci-all"}`'
+    RemoveBastionNodes:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/bastion/{bastionVmId}
+      description: Remove a bastion VM from all vNets
+    RemoveBastionNodesWithInfra:
+
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/bastion/{bastionMciId}/{bastionVmId}
+      description: Remove a specific cross-MCI bastion from all vNets of the target MCI
+    RemoveBastionNodesWithNs:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/bastion/{bastionNsId}/{bastionMciId}/{bastionVmId}
+      description: Remove a specific cross-namespace bastion from all vNets of the target MCI
+    RemoveLabel:
+      method: delete
+      resourcePath: /label/{labelType}/{uid}/{key}
+      description: Remove a label from a resource identified by its uid
+    RemoveNLBVMs:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}/node
+      description: Delete VMs from NLB
+    RestDeleteObjectStorage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+      description: Delete an object storage (bucket)
+    RetrieveRegionListFromCsp:
+      method: get
+      resourcePath: /regionFromCsp
+      description: RetrieveR all region lists from CSPs
+    SearchImage:
+      method: post
+      resourcePath: /ns/{nsId}/resources/searchImage
+      description: Search image
+    SearchImageOptions:
+      method: get
+      resourcePath: /ns/{nsId}/resources/searchImageOptions
+      description: Get all available options for image search fields
+    SetBastionNodes:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{targetVmId}/bastion/{bastionVmId}
+      description: "Set bastion nodes for a VM"
     Inspectresourcesoverview:
       method: get
       resourcePath: /inspectResourcesOverview
@@ -1949,10 +4479,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}
       description: "Remove a K8sNodeGroup"
-    Getsitesinmci:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/site
-      description: "Get sites in MCI"
     Getalldatadisk:
       method: get
       resourcePath: /ns/{nsId}/resources/dataDisk
@@ -1969,36 +4495,200 @@ serviceActions:
       method: post
       resourcePath: /ns/{nsId}/sharedResource
       description: "Create shared resources for MC-Infra"
-    GetCredentialHolderList:
+    ListVNet:
       method: get
-      resourcePath: /credentialHolder
-      description: "List all credential holders derived from registered connection configs."
-    GetAssetsSummary:
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: "List all VNets in a namespace"
+    CreateVNet:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: "Create VNet"
+    DeleteVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+      description: "Delete VNet"
+    ListSecurityGroup:
       method: get
-      resourcePath: /assetsSummary
-      description: "Returns CSP-wise summary of specs and images in DB for a namespace."
-    PostMciSubGroupDynamic:
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: "List all Security Groups in a namespace"
+    CreateSecurityGroup:
       method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/subGroupDynamic
-      description: "Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management"
-    RecommendSpec:
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: "Create Security Group"
+    DeleteSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: "Delete Security Group"
+    ListSSHKey:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: "List all SSH Keys in a namespace"
+    CreateSSHKey:
       method: post
-      resourcePath: /recommendSpec
-      description: "Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
-    Postclusterremotecmd:
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: "Create SSH Key"
+    ListImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/image
+      description: "List all images in a namespace"
+    RegisterImage:
       method: post
-      resourcePath: /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}
-      description: "Send a command to specified Cluster"
-    Postmcidynamicreview:
+      resourcePath: /ns/{nsId}/resources/image
+      description: "Register image in a namespace"
+    DeleteImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: "Delete image"
+    ListSpec:
       method: post
-      resourcePath: /ns/{nsId}/mciDynamicReview
-      description: "Create MCI Dynamically from common spec and image"
+      resourcePath: /ns/{nsId}/resources/filterSpecsByRange
+      description: "List all specs in a namespace"
+    RegisterSpec:
+      method: post
+      resourcePath: /ns/{nsId}/resources/spec
+      description: "Register spec in a namespace"
+    DeleteSpec:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: "Delete spec"
+    SetBastionNodesWithInfra:
 
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{targetVmId}/bastion/{bastionMciId}/{bastionVmId}
+      description: Set bastion nodes for a target VM, specifying a bastion VM that belongs to a different MCI within the same namespace (cross-MCI bastion). This allows, for example, an AWS VM to serve as a bastion for an OpenStack VM.
+    SetBastionNodesWithNs:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{targetVmId}/bastion/{bastionNsId}/{bastionMciId}/{bastionVmId}
+      description: Set bastion nodes for a target VM, specifying a bastion VM that belongs to a different namespace and MCI (cross-namespace bastion). This allows, for example, a VM in a shared-services namespace to act as a bastion for VMs in other namespaces.
+    SetObjectStorageCORS:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+      description: Set CORS configuration of an object storage (bucket)
+    SetObjectStorageCORSLagacy:
+      method: put
+      resourcePath: /resources/objectStorage/{objectStorageName}/cors
+      description: '(To be deprecated) Set CORS configuration of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The CORS configuration must be provided in the request body in XML format.
+
+        - The actual request body should have root element `CORSConfiguration`
+
+
+        **Actual XML Request Body Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <CORSConfiguration>
+
+        <CORSRule>
+
+        <AllowedOrigin>https://example.com</AllowedOrigin>
+
+        <AllowedOrigin>https://app.example.com</AllowedOrigin>
+
+        <AllowedMethod>GET</AllowedMethod>
+
+        <AllowedMethod>PUT</AllowedMethod>
+
+        <AllowedHeader>Content-Type</AllowedHeader>
+
+        <AllowedHeader>Authorization</AllowedHeader>
+
+        <ExposeHeader>ETag</ExposeHeader>
+
+        <MaxAgeSeconds>1800</MaxAgeSeconds>
+
+        </CORSRule>
+
+        <CORSRule>
+
+        <AllowedOrigin>*</AllowedOrigin>
+
+        <AllowedMethod>GET</AllowedMethod>
+
+        <MaxAgeSeconds>300</MaxAgeSeconds>
+
+        </CORSRule>
+
+        </CORSConfiguration>
+
+        ```'
+    SetObjectStorageVersioning:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
+      description: 'Set versioning configuration of an object storage (bucket)
+
+
+        **Note: **
+
+        - Versioning options: "Enabled", "Suspended", "Unversioned"
+
+        '
+    SetObjectStorageVersioningLagacy:
+      method: put
+      resourcePath: /resources/objectStorage/{objectStorageName}/versioning
+      description: '(To be deprecated) Set versioning status of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The request body must be XML format with root element `VersioningConfiguration`
+
+        - The `Status` field can be either `Enabled` or `Suspended`
+
+
+        **Request Body Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Status>Enabled</Status>
+
+        </VersioningConfiguration>
+
+        ```'
+    SetSystemInitialized:
+      method: put
+      resourcePath: /readyz/init
+      description: Set the system initialization status to true. Called by init.py after completing initialization.
+    TestJWTAuth:
+      method: get
+      resourcePath: /auth/test
+      description: Test JWT authentication
+    UnsetSystemInitialized:
+      method: delete
+      resourcePath: /readyz/init
+      description: Reset the system initialization status to false. Useful for re-initialization scenarios.
+    UpdateExistingSpecListByAvailableRegionZones:
+      method: post
+      resourcePath: /ns/{nsId}/updateExistingSpecListByAvailableRegionZones
+      description: Query all specs for a specific provider across all regions, check their availability, and remove specs that are not available in their respective regions
+    UpdateImagesFromAsset:
+      method: post
+      resourcePath: /updateImagesFromAsset
+      description: Update image information based on the cloudimage.csv asset file
+    PostFileAndCmdToInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/transferFileAndCmd/infra/{infraId}
+      description: 'Transfer a file and execute commands on all nodes in the Infra. (v0.12.9 갱신: /ns/{nsId}/mci/{mciId}/fileAndCmd → /ns/{nsId}/transferFileAndCmd/infra/{infraId})'
   mc-web-console:
     Anycontroller:
       method: post
       resourcePath: /api/{operationId}
       description: AnyController
+    getSetupYamlCheck:
+      method: get
+      resourcePath: /api/admin/setup-yaml-check
+      description: "FR-CLOUD-ADMIN-006-08 — 외부 raw YAML(menu/api) 도달성 확인 BFF endpoint. query: which=menu|api"
     Availabledisktypebyproviderregion:
       method: post
       resourcePath: /api/availabledisktypebyproviderregion
@@ -2023,10 +4713,6 @@ serviceActions:
       method: post
       resourcePath: /api/auth/login
       description: webLogin
-    Webloginrefresh:
-      method: post
-      resourcePath: /api/auth/refresh
-      description: webLoginRefresh
     Weblogout:
       method: post
       resourcePath: /api/auth/logout
@@ -2035,857 +4721,921 @@ serviceActions:
       method: post
       resourcePath: /api/auth/validate
       description: webValidate
-    getSetupYamlCheck:
-      method: get
-      resourcePath: /api/admin/setup-yaml-check
-      description: "외부 raw YAML(menu/api) 도달성 확인 BFF endpoint. query: which=menu|api"
-
   mc-observability:
-    Poststorage:
-      method: post
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage
-      description: ""
-    Getstorages:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage
-      description: ""
-    Putstorage:
-      method: put
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage
-      description: ""
-    Getminingdbtags:
-      method: get
-      resourcePath: /api/o11y/monitoring/miningdb/tag
-      description: ""
-    Gettargetanomalydetectionsettings:
-      method: get
-      resourcePath: /api/o11y/insight/anomaly-detection/settings/nsId/{nsId}/target/{targetId}
-      description: "Fetch the current settings for a specific anomaly detection target."
-    Postanomalydetection:
-      method: post
-      resourcePath: /api/o11y/insight/anomaly-detection/{settingSeq}
-      description: "Request anomaly detection"
-    Getpredictionoptions:
-      method: get
-      resourcePath: /api/o11y/insight/predictions/options
-      description: "Fetch the available target types, metric types, and prediction range options for the prediction API."
-    Gettargetsnsmci:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target
-      description: ""
-    Putitem:
-      method: put
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/item
-      description: ""
-    Postitem:
-      method: post
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/item
-      description: ""
-    Getitems:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/item
-      description: ""
-    Gettriggeralertslackuseralllist:
-      method: get
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/slack
-      description: ""
-    Createtriggeralertslackuser:
-      method: post
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/slack
-      description: ""
-    Deletetriggeralertslackuser:
-      method: delete
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/slack/{seq}
-      description: ""
-    Getminingdbs:
-      method: get
-      resourcePath: /api/o11y/monitoring/miningdb
-      description: ""
-    Putminingdb:
-      method: put
-      resourcePath: /api/o11y/monitoring/miningdb
-      description: ""
-    Gettargets:
-      method: get
-      resourcePath: /api/o11y/monitoring/target
-      description: ""
-    Deletestorage:
-      method: delete
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage/{storageSeq}
-      description: ""
-    Deleterequesttriggerpolicy:
-      method: delete
-      resourcePath: /api/o11y/trigger/policy/{policySeq}
-      description: ""
-    Updaterequesttriggerpolicy:
-      method: patch
-      resourcePath: /api/o11y/trigger/policy/{policySeq}
-      description: ""
-    Getreadyz:
+    GetObsReadyz:
       method: get
       resourcePath: /api/o11y/readyz
-      description: ""
-    Getplugins:
+      description: "mc-observability 헬스체크."
+    LogLabelsQuery:
       method: get
-      resourcePath: /api/o11y/monitoring/plugins
-      description: ""
-    Getopensearchlogs:
-      method: post
-      resourcePath: /api/o11y/monitoring/opensearch/logs
-      description: ""
-    Gettriggerpolicyalllist:
+      resourcePath: /api/o11y/log/labels
+      description: Retrieve the list of label keys provided by Loki.
+    LogVolumeQuery:
       method: get
-      resourcePath: /api/o11y/trigger/policy
-      description: ""
-    Createrequesttriggerpolicy:
-      method: post
-      resourcePath: /api/o11y/trigger/policy
-      description: "The values that require Base64 encoding:\ndescription, name, threshold\n"
-    Getallanomalydetectionsettings:
+      resourcePath: /api/o11y/log/log_volumes
+      description: Retrieve log volumes (metric time series data) for the given period.
+    LogRangeQuery:
       method: get
-      resourcePath: /api/o11y/insight/anomaly-detection/settings
-      description: "Fetch the current settings for all anomaly detection targets."
-    Postanomalydetectionsettings:
-      method: post
-      resourcePath: /api/o11y/insight/anomaly-detection/settings
-      description: "Register a target for anomaly detection and automatically schedule detection tasks.  \n(measurememt : field) Relationships are as follows.  \ncpu : usage_idle  \nmem : used_percent\n"
-    Getnss:
-      method: get
-      resourcePath: /api/o11y/monitoring/ns
-      description: ""
-    Getinfluxdbmetrics:
-      method: post
-      resourcePath: /api/o11y/monitoring/influxdb/metric
-      description: ""
-    Putanomalydetectionsettings:
-      method: put
-      resourcePath: /api/o11y/insight/anomaly-detection/settings/{settingSeq}
-      description: "Modify the settings for a specific anomaly detection target, including the monitoring metric and interval."
-    Deleteanomalydetectionsettings:
-      method: delete
-      resourcePath: /api/o11y/insight/anomaly-detection/settings/{settingSeq}
-      description: "Remove a target from anomaly detection, stopping and removing any scheduled tasks."
-    Deleteitem:
-      method: delete
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/item/{itemSeq}
-      description: ""
-    Getinfluxdbmeasurements:
-      method: get
-      resourcePath: /api/o11y/monitoring/influxdb/measurement
-      description: ""
-    Gettriggerhistoryalllist:
-      method: get
-      resourcePath: /api/o11y/trigger/policy/history
-      description: "Base64 Encoded value:  \nname\n"
-    Postprediction:
-      method: post
-      resourcePath: /api/o11y/insight/predictions/nsId/{nsId}/target/{targetId}
-      description: "Predict future metrics (cpu, mem, disk, system) for a given vm or mci group.\n(measurememt : field) Relationships are as follows.  \ncpu : usage_idle  \nmem : used_percent  \ndisk : used_percent  \nsystem : load1\n"
-    Getpredictionhistory:
-      method: get
-      resourcePath: /api/o11y/insight/predictions/nsId/{nsId}/target/{targetId}/history
-      description: "Get previously stored prediction data for a specific vm or mci group."
-    Getinfluxdbtags:
-      method: get
-      resourcePath: /api/o11y/monitoring/influxdb/tag
-      description: ""
-    Getcsp:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/csp/{measurement}
-      description: ""
-    Puttriggertarget:
-      method: put
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/target
-      description: ""
-    Deletetriggeralertemailuser:
-      method: delete
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/email/{seq}
-      description: ""
-    Getanomalydetectionoptions:
-      method: get
-      resourcePath: /api/o11y/insight/anomaly-detection/options
-      description: "Fetch the available target types, metric types, and interval options for the anomaly detection API."
-    Gettriggertargetalllist:
-      method: get
-      resourcePath: /api/o11y/trigger/policy/target
-      description: ""
-    Gettriggeralertemailuseralllist:
-      method: get
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/email
-      description: ""
-    Createtriggeralertemailuser:
-      method: post
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/email
-      description: ""
-    Getanomalydetectionhistory:
-      method: get
-      resourcePath: /api/o11y/insight/anomaly-detection/nsId/{nsId}/target/{targetId}/history
-      description: "Fetch the results of anomaly detection for a specific target within a given time range."
-    Gettarget:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}
-      description: ""
-    Puttarget:
-      method: put
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}
-      description: ""
-    Posttarget:
-      method: post
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}
-      description: ""
-    Deletetarget:
-      method: delete
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}
-      description: ""
-    Getminingdbmetrics:
-      method: post
-      resourcePath: /api/o11y/monitoring/miningdb/metric
-      description: ""
-    Getminingdbmeasurements:
-      method: get
-      resourcePath: /api/o11y/monitoring/miningdb/measurement
-      description: ""
-    Getopensearches:
-      method: get
-      resourcePath: /api/o11y/monitoring/opensearch
-      description: ""
-    Getinfluxdbs:
+      resourcePath: /api/o11y/log/query_range
+      description: Retrieve log data for a specific query within a given time range.
+    GetAllInfluxDB:
       method: get
       resourcePath: /api/o11y/monitoring/influxdb
-      description: ""
-
+      description: Retrieve all InfluxDB servers
+    GetPlugins:
+      method: get
+      resourcePath: /api/o11y/monitoring/plugins
+      description: Retrieve plugin list
+    GetAllVMs:
+      method: get
+      resourcePath: /api/o11y/monitoring/vm
+      description: Retrieve all targets
+    GetPaginatedTriggerHistories:
+      method: get
+      resourcePath: /api/o11y/trigger/history
+      description: Get paginated trigger histories
+    GetPaginatedTriggerPolicies:
+      method: get
+      resourcePath: /api/o11y/trigger/policy
+      description: Get paginated trigger policies
+    CreateTriggerPolicy:
+      method: post
+      resourcePath: /api/o11y/trigger/policy
+      description: Create trigger policy
+    GetMeasurementFields:
+      method: get
+      resourcePath: /api/o11y/monitoring/influxdb/measurement
+      queryParams:
+      description: Retrieve InfluxDB measurements
+    GetMeasurementTags:
+      method: get
+      resourcePath: /api/o11y/monitoring/influxdb/tag
+      description: Retrieve InfluxDB tags
+    GetAllAlertRules:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/alert-rules
+      description: Get all alert rules
+    GetAllAlerts:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/alerts
+      description: Get all alerts
+    GetAllContactPoints:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/contact-points
+      description: Get all contact points
+    CheckGrafanaHealthStatus:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/health
+      description: Check grafana health status
+    GetPaginatedAlertTestHistories:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/test-history
+      description: Get paginated alert test histories
+    GetSupportedNotificationChannels:
+      method: get
+      resourcePath: /api/o11y/trigger/noti/channel
+      description: Get supported notification channels
+    GetPaginatedNotificationHistories:
+      method: get
+      resourcePath: /api/o11y/trigger/noti/history
+      description: Get paginated notification histories
+    DeleteTriggerPolicy:
+      method: delete
+      resourcePath: /api/o11y/trigger/policy/{id}
+      description: Delete trigger policy
+    LabelValueQuery:
+      method: get
+      resourcePath: /api/o11y/log/labels/{label}/values
+      description: Retrieve the list of values for a specific label key.
+    GetVMByNsMci:
+      method: get
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm
+      description: Retrieve target list by NS/MCI
+    TestAlertReceiverConnection:
+      method: post
+      resourcePath: /api/o11y/trigger/alert/alert-receiver/test
+      description: Test alert receiver connection
+    SearchAlertsByTitle:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/alerts/search
+      description: Search alerts by title
+    UpdateTriggerHistoryComment:
+      method: put
+      resourcePath: /api/o11y/trigger/history/{id}/comment
+      description: Update trigger history comment
+    UpdateTriggerPolicyNotificationChannels:
+      method: put
+      resourcePath: /api/o11y/trigger/policy/{id}/channel
+      description: Update trigger policy notification channels
+    AddTriggerVM:
+      method: post
+      resourcePath: /api/o11y/trigger/policy/{id}/vm
+      description: Add trigger vm
+    RemoveTriggerVM:
+      method: delete
+      resourcePath: /api/o11y/trigger/policy/{id}/vm
+      description: Remove trigger vm
+    GetMetricsByVMId:
+      method: post
+      resourcePath: /api/o11y/monitoring/influxdb/metric/{nsId}/{mciId}/{vmId}
+      description: Retrieve InfluxDB metrics
+    GetMetricsByNsIdAndMciId:
+      method: post
+      resourcePath: /api/o11y/monitoring/influxdb/metric/{nsId}/{mciId}
+      description: Retrieve InfluxDB metrics
+    GetVM:
+      method: get
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}
+      description: Retrieve single target
+    PostVM:
+      method: post
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}
+      description: Create target (VM)
+    PutVM:
+      method: put
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}
+      description: Update target
+    DeleteVM:
+      method: delete
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}
+      description: Delete target
+    GetMonitoringItems:
+      method: get
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}/item
+      description: Retrieve monitoring item list
+    AddMonitoringItem:
+      method: post
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}/item
+      description: Add monitoring item
+    UpdateMonitoringItem:
+      method: put
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}/item
+      description: Update monitoring item
+    DeleteMonitoringItem:
+      method: delete
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}/item/{itemSeq}
+      description: Delete monitoring item
+    UpdateAnomalySetting:
+      method: put
+      resourcePath: /api/o11y/insight/anomaly-detection/settings/{settingSeq}
+      description: updateAnomalySetting
+    DeleteAnomalySetting:
+      method: delete
+      resourcePath: /api/o11y/insight/anomaly-detection/settings/{settingSeq}
+      description: deleteAnomalySetting
+    PredictMonitoringDataForMci:
+      method: post
+      resourcePath: /api/o11y/insight/predictions/ns/{nsId}/mci/{mciId}
+      description: predictMonitoringDataForMci
+    PredictMonitoringDataForVm:
+      method: post
+      resourcePath: /api/o11y/insight/predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}
+      description: predictMonitoringDataForVm
+    QueryLogAnalysis:
+      method: post
+      resourcePath: /api/o11y/insight/log-analysis/query
+      description: queryLogAnalysis
+    GetLLMChatSessions:
+      method: get
+      resourcePath: /api/o11y/insight/llm/session
+      description: getLLMChatSessions
+    PostLLMChatSession:
+      method: post
+      resourcePath: /api/o11y/insight/llm/session
+      description: postLLMChatSession
+    DeleteLLMChatSession:
+      method: delete
+      resourcePath: /api/o11y/insight/llm/session
+      description: deleteLLMChatSession
+    GetLLMApiKeys:
+      method: get
+      resourcePath: /api/o11y/insight/llm/api-keys
+      description: getLLMApiKeys
+    PostLLMApiKeys:
+      method: post
+      resourcePath: /api/o11y/insight/llm/api-keys
+      description: postLLMApiKeys
+    PredictAnomalyDetection:
+      method: post
+      resourcePath: /api/o11y/insight/anomaly-detection/{settingSeq}
+      description: predictAnomalyDetection
+    GetAnomalySettings:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/settings
+      description: getAnomalySettings
+    CreateAnomalySetting:
+      method: post
+      resourcePath: /api/o11y/insight/anomaly-detection/settings
+      description: createAnomalySetting
+    QueryAlertAnalysis:
+      method: post
+      resourcePath: /api/o11y/insight/alert-analysis/query
+      description: queryAlertAnalysis
+    GetPredictionOptions:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/options
+      description: getPredictionOptions
+    GetPredictionVMHistory:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}/history
+      description: getPredictionVMHistory
+    GetPredictionMCIHistory:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/ns/{nsId}/mci/{mciId}/history
+      description: getPredictionMCIHistory
+    GetPredictionMeasurements:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/measurement
+      description: getPredictionMeasurements
+    GetPredictionSpecificMeasurement:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/measurement/{measurement}
+      description: getPredictionSpecificMeasurement
+    GetLLMSessionHistory:
+      method: get
+      resourcePath: /api/o11y/insight/llm/session/{sessionId}/history
+      description: getLLMSessionHistory
+    GetLLMModelOptions:
+      method: get
+      resourcePath: /api/o11y/insight/llm/model
+      description: getLLMModelOptions
+    GetAnomalySettingsForMci:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/settings/ns/{nsId}/mci/{mciId}
+      description: getAnomalySettingsForMci
+    GetAnomalySettingsForVm:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/settings/ns/{nsId}/mci/{mciId}/vm/{vmId}
+      description: getAnomalySettingsForVm
+    GetOptions:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/options
+      description: getOptions
+    GetAnomalyDetectionVMHistory:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/ns/{nsId}/mci/{mciId}/vm/{vmId}/history
+      description: getAnomalyDetectionVMHistory
+    GetAnomalyDetectionMCIHistory:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/ns/{nsId}/mci/{mciId}/history
+      description: getAnomalyDetectionMCIHistory
+    GetMeasurements:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/measurement
+      description: getMeasurements
+    GetSpecificMeasurement:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/measurement/{measurement}
+      description: getSpecificMeasurement
+    DeleteAllLLMChatSessions:
+      method: delete
+      resourcePath: /api/o11y/insight/llm/sessions
+      description: deleteAllLLMChatSessions
+    DeleteLLMApiKeys:
+      method: delete
+      resourcePath: /api/o11y/insight/llm/api-Keys
+      description: deleteLLMApiKeys
   mc-application-manager:
+    GetAppMgrReadyz:
+      method: get
+      resourcePath: /readyz
+      description: "mc-application-manager 헬스체크."
     GetCatalogDetailUsingGET:
       method: get
       resourcePath: /catalog/software/{catalogIdx}
-      description: "software catalog 내용 확인(연결된 정보들까지)"
+      description: software catalog 내용 확인(연결된 정보들까지)
     DeleteCatalogUsingDELETE:
       method: delete
       resourcePath: /catalog/software/{catalogIdx}
-      description: "software catalog 삭제"
+      description: software catalog 삭제
     CheckConnectionUsingPOST:
       method: post
       resourcePath: /oss/connection-check
-      description: ""
+      description: ''
     CreateComponentByTextUsingPOST:
       method: post
       resourcePath: /oss/v1/components/{module}/create/{name}/text
-      description: ""
+      description: ''
     DeleteRepositoryUsingDELETE:
       method: delete
       resourcePath: /oss/v1/repositories/{module}/delete/{name}
-      description: ""
+      description: ''
     UpdateRepositoryUsingPUT:
       method: put
       resourcePath: /oss/v1/repositories/{module}/update
-      description: ""
+      description: ''
     GenerateDeploymentYamlUsingPOST:
       method: post
       resourcePath: /yaml/deployment
-      description: ""
+      description: ''
     GeneratePodYamlUsingPOST:
       method: post
       resourcePath: /yaml/pod
-      description: ""
+      description: ''
     IsOssInfoDuplicatedUsingGET:
       method: get
       resourcePath: /oss/duplicate
-      description: ""
+      description: ''
     CreateComponentUsingPOST:
       method: post
       resourcePath: /oss/v1/components/{module}/create/{name}
-      description: ""
+      description: ''
     GetRepositoryListUsingGET:
       method: get
       resourcePath: /oss/v1/repositories/{module}/list
-      description: ""
+      description: ''
     DeleteOssTypeUsingDELETE:
       method: delete
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     UpdateOssTypeUsingPATCH:
       method: patch
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     DetailOssTypeUsingGET:
       method: get
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     GetRepositoryUsingGET:
       method: get
       resourcePath: /repository/{repositoryName}
-      description: ""
+      description: ''
     InsertRepositoryUsingPOST:
       method: post
       resourcePath: /repository/{repositoryName}
-      description: ""
+      description: ''
     OpenapiJsonUsingGET:
       method: get
       resourcePath: /v3/api-docs
-      description: ""
+      description: ''
     SaveManifestUsingGET:
       method: get
       resourcePath: /manifest/download/{manifestIdx}
-      description: ""
+      description: ''
     DeleteComponentUsingDELETE:
       method: delete
       resourcePath: /oss/v1/components/{module}/delete/{id}
-      description: ""
+      description: ''
     GenerateConfigmapYamlUsingPOST:
       method: post
       resourcePath: /yaml/configmap
-      description: ""
+      description: ''
     GetManifestUsingGET:
       method: get
       resourcePath: /manifest/
-      description: ""
+      description: ''
     CreateManifestUsingPOST:
       method: post
       resourcePath: /manifest/
-      description: ""
+      description: ''
     UpdateManifestUsingPUT:
       method: put
       resourcePath: /manifest/
-      description: ""
+      description: ''
     GetManifestDetailUsingGET:
       method: get
       resourcePath: /manifest/{manifestIdx}
-      description: ""
+      description: ''
     UpdateManifestUsingDELETE:
       method: delete
       resourcePath: /manifest/{manifestIdx}
-      description: ""
+      description: ''
     GetOssListUsingGET_1:
       method: get
       resourcePath: /oss/list
-      description: ""
+      description: ''
     GetRepositoryDetailByNameUsingGET:
       method: get
       resourcePath: /oss/v1/repositories/{module}/detail/{name}
-      description: ""
+      description: ''
     RegistOssTypeUsingPOST:
       method: post
       resourcePath: /ossType
-      description: ""
+      description: ''
     GetRepositoryFileUsingGET:
       method: get
       resourcePath: /repository/file/{filename}
-      description: ""
+      description: ''
     DeleteRepositoryFileUsingDELETE:
       method: delete
       resourcePath: /repository/file/{filename}
-      description: ""
+      description: ''
     OpenapiJsonUsingGET_1:
       method: get
       resourcePath: /v3/api-docs/swagger-config
-      description: ""
+      description: ''
     GetCatalogListUsingGET:
       method: get
       resourcePath: /catalog/software/
-      description: "software catalog 리스트 불러오기"
+      description: software catalog 리스트 불러오기
     CreateCatalogUsingPOST:
       method: post
       resourcePath: /catalog/software/
-      description: "software catalog 등록"
+      description: software catalog 등록
     UpdateCatalogUsingPUT:
       method: put
       resourcePath: /catalog/software/
-      description: "software catalog 수정"
+      description: software catalog 수정
     DeleteCatalogRefWorkflowUsingDELETE:
       method: delete
       resourcePath: /catalog/software/ref/{catalogIdx}/{catalogRefIdx}
-      description: ""
+      description: ''
     GetComponentDetailByNameUsingGET:
       method: get
       resourcePath: /oss/v1/components/{module}/detail/{id}
-      description: ""
+      description: ''
     GenerateHPAYamlUsingPOST:
       method: post
       resourcePath: /yaml/hpa
-      description: ""
+      description: ''
     ExecWorkflowUsingPOST:
       method: post
       resourcePath: /catalog/software/ref/workflow
-      description: ""
+      description: ''
     GetCatalogReferenceUsingGET:
       method: get
       resourcePath: /catalog/software/ref/{catalogIdx}
-      description: ""
+      description: ''
     CreateCatalogRefUsingPOST:
       method: post
       resourcePath: /catalog/software/ref/{catalogIdx}
-      description: "software catalog 관련정보 등록(webpage, workflow 등)"
+      description: software catalog 관련정보 등록(webpage, workflow 등)
     GetManifestDetailTxtUsingGET:
       method: get
       resourcePath: /manifest/{manifestIdx}/txt
-      description: ""
+      description: ''
     DetailOssUsingGET:
       method: get
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     DeleteOssUsingDELETE:
       method: delete
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     UpdateOssUsingPATCH:
       method: patch
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     GetOssTypeListUsingGET:
       method: get
       resourcePath: /ossType/list
-      description: ""
+      description: ''
     GetDockerHubListUsingGET:
       method: get
       resourcePath: /search/dockerhub/{keyword}
-      description: ""
+      description: ''
     GenerateServiceYamlUsingPOST:
       method: post
       resourcePath: /yaml/service
-      description: ""
+      description: ''
     ErrorHtmlUsingHEAD:
       method: head
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingPOST:
       method: post
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingPUT:
       method: put
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingDELETE:
       method: delete
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingOPTIONS:
       method: options
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingPATCH:
       method: patch
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingGET:
       method: get
       resourcePath: /error
-      description: ""
+      description: ''
     RegistOssUsingPOST:
       method: post
       resourcePath: /oss
-      description: ""
+      description: ''
     GetOssListUsingGET:
       method: get
       resourcePath: /oss/list/{ossTypeName}
-      description: ""
+      description: ''
     UploadFilesUsingPOST:
       method: post
       resourcePath: /repository/file/
-      description: "file upload"
+      description: file upload
     RedirectToUiUsingGET:
       method: get
       resourcePath: /swagger-ui.html
-      description: ""
+      description: ''
     OpenapiYamlUsingGET:
       method: get
       resourcePath: /v3/api-docs.yaml
-      description: ""
+      description: ''
     GetComponentListUsingGET:
       method: get
       resourcePath: /oss/v1/components/{module}/list/{name}
-      description: ""
+      description: ''
     CreateRepositoryUsingPOST:
       method: post
       resourcePath: /oss/v1/repositories/{module}/create
-      description: ""
+      description: ''
     CreateRepositoryUsingPOST_1:
       method: post
       resourcePath: /repository/
-      description: ""
+      description: ''
     UpdateRepositoryUsingPUT_1:
       method: put
       resourcePath: /repository/
-      description: ""
+      description: ''
     DeleteRepositoryUsingDELETE_1:
       method: delete
       resourcePath: /repository/
-      description: ""
+      description: ''
     GetRepositoryListUsingGET_1:
       method: get
       resourcePath: /repository/
-      description: ""
+      description: ''
     GetArtifactHubListUsingGET:
       method: get
       resourcePath: /search/artifacthub/{keyword}
-      description: ""
-
+      description: ''
   mc-workflow-manager:
+    GetWorkflowReadyz:
+      method: get
+      resourcePath: /readyz
+      description: "mc-workflow-manager 헬스체크."
     IsWorkflowNameDuplicatedUsingGET:
       method: get
       resourcePath: /workflow/name/duplicate
-      description: ""
+      description: ''
     GetWorkflowParamListUsingGET:
       method: get
       resourcePath: /workflow/param/list
-      description: ""
+      description: ''
     RegistWorkflowStageUsingPOST:
       method: post
       resourcePath: /workflowStage
-      description: ""
+      description: ''
     DetailEventListenerUsingGET:
       method: get
       resourcePath: /eventlistener/{eventListenerIdx}
-      description: ""
+      description: ''
     DeleteEventListnerUsingDELETE:
       method: delete
       resourcePath: /eventlistener/{eventListenerIdx}
-      description: ""
+      description: ''
     UpdateEventListnerUsingPATCH:
       method: patch
       resourcePath: /eventlistener/{eventListenerIdx}
-      description: ""
+      description: ''
     DetailOssTypeUsingGET:
       method: get
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     DeleteOssTypeUsingDELETE:
       method: delete
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     UpdateOssTypeUsingPATCH:
       method: patch
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     OpenapiYamlUsingGET:
       method: get
       resourcePath: /v3/api-docs.yaml
-      description: ""
+      description: ''
     OpenapiJsonUsingGET_1:
       method: get
       resourcePath: /v3/api-docs/swagger-config
-      description: ""
+      description: ''
     GetWorkflowHistoryListUsingGET:
       method: get
       resourcePath: /workflow/history/{workflowIdx}
-      description: ""
+      description: ''
     DetailOssUsingGET:
       method: get
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     DeleteOssUsingDELETE:
       method: delete
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     UpdateOssUsingPATCH:
       method: patch
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     RegistOssTypeUsingPOST:
       method: post
       resourcePath: /ossType
-      description: ""
+      description: ''
     OpenapiJsonUsingGET:
       method: get
       resourcePath: /v3/api-docs
-      description: ""
+      description: ''
     RunWorkflowGetUsingGET:
       method: get
       resourcePath: /workflow/run/{workflowIdx}
-      description: ""
+      description: ''
     DetailWorkflowStageUsingGET:
       method: get
       resourcePath: /workflowStage/{workflowStageIdx}
-      description: ""
+      description: ''
     DeleteWorkflowStageUsingDELETE:
       method: delete
       resourcePath: /workflowStage/{workflowStageIdx}
-      description: ""
+      description: ''
     UpdateWorkflowStageUsingPATCH:
       method: patch
       resourcePath: /workflowStage/{workflowStageIdx}
-      description: ""
+      description: ''
     GetEventListenerListUsingGET:
       method: get
       resourcePath: /eventlistener/list
-      description: ""
+      description: ''
     RegistWorkflowUsingPOST:
       method: post
       resourcePath: /workflow
-      description: ""
+      description: ''
     GetWorkflowStageListUsingGET:
       method: get
       resourcePath: /workflow/workflowStageList
-      description: ""
+      description: ''
     GetWorkflowUsingGET:
       method: get
       resourcePath: /workflow/{workflowIdx}
-      description: ""
+      description: ''
     DeleteWorkflowUsingDELETE:
       method: delete
       resourcePath: /workflow/{workflowIdx}
-      description: ""
+      description: ''
     UpdateWorkflowUsingPATCH:
       method: patch
       resourcePath: /workflow/{workflowIdx}
-      description: ""
+      description: ''
     GetDefaultWorkflowStageUsingGET:
       method: get
       resourcePath: /workflowStage/default/script/{workflowStageTypeName}
-      description: ""
+      description: ''
     RegistEventListnerUsingPOST:
       method: post
       resourcePath: /eventlistener
-      description: ""
+      description: ''
     CheckConnectionUsingPOST:
       method: post
       resourcePath: /oss/connection-check
-      description: ""
+      description: ''
     GetWorkflowListUsingGET:
       method: get
       resourcePath: /workflow/list
-      description: ""
+      description: ''
     GetWorkflowTemplateUsingGET:
       method: get
       resourcePath: /workflow/template/{workflowName}
-      description: ""
+      description: ''
     RedirectToUiUsingGET:
       method: get
       resourcePath: /swagger-ui.html
-      description: ""
+      description: ''
     RegistWorkflowStageUsingPOST_1:
       method: post
       resourcePath: /workflowStageType
-      description: ""
+      description: ''
     GetWorkflowStageListUsingGET_2:
       method: get
       resourcePath: /workflowStageType/list
-      description: ""
+      description: ''
     GetOssListUsingGET_1:
       method: get
       resourcePath: /oss/list
-      description: ""
+      description: ''
     GetOssTypeListUsingGET:
       method: get
       resourcePath: /ossType/list
-      description: ""
+      description: ''
     IsWorkflowStageNameDuplicatedUsingGET:
       method: get
       resourcePath: /workflowStage/duplicate
-      description: ""
+      description: ''
     DetailWorkflowStageTypeUsingGET:
       method: get
       resourcePath: /workflowStageType/{workflowStageTypeIdx}
-      description: ""
+      description: ''
     DeleteWorkflowStageTypeUsingDELETE:
       method: delete
       resourcePath: /workflowStageType/{workflowStageTypeIdx}
-      description: ""
+      description: ''
     UpdateWorkflowStageTypeUsingPATCH:
       method: patch
       resourcePath: /workflowStageType/{workflowStageTypeIdx}
-      description: ""
+      description: ''
     GetWorkflowStageListUsingGET_1:
       method: get
       resourcePath: /workflowStage/list
-      description: ""
+      description: ''
     RunEventListenerUsingGET:
       method: get
       resourcePath: /eventlistener/run/{eventListenerIdx}
-      description: ""
+      description: ''
     RegistOssUsingPOST:
       method: post
       resourcePath: /oss
-      description: ""
+      description: ''
     IsOssInfoDuplicatedUsingGET:
       method: get
       resourcePath: /oss/duplicate
-      description: ""
+      description: ''
     GetOssListUsingGET:
       method: get
       resourcePath: /oss/list/{ossTypeName}
-      description: ""
+      description: ''
     RunWorkflowPostUsingPOST:
       method: post
       resourcePath: /workflow/run
-      description: ""
-
+      description: ''
   mc-cost-optimizer:
-    GetProjects:
-      method: get
-      resourcePath: /api/v2/getProjects
-      description: "워크스페이스에 속한 프로젝트 목록을 조회합니다."
-    GetUnusedRec:
-      method: post
-      resourcePath: /api/v2/opti/unusedRec
-      description: "이번달 CSP별 요약된 빌링 인보이스를 확인한다."
-    GetSummary:
-      method: post
-      resourcePath: /api/v2/invoice/getSummary
-      description: "CSP별 빌링 인보이스 비용을 날짜별로 확인한다."
-    GetInvoice:
-      method: post
-      resourcePath: /api/v2/invoice/getInvoice
-      description: "이번달 빌링 인보이스 내역을 확인한다."
-    GetBillingBaseInfo:
-      method: post
-      resourcePath: /api/v2/invoice/getBillingBaseInfo
-      description: "이번달 CSP별 요약된 빌링 인보이스를 확인한다."
-    GetTop5Bill:
-      method: post
-      resourcePath: /api/v2/getTop5Bill
-      description: "이번달에 사용한 비용 상위 5개의 리소스와 비용을 확인합니다."
-    GetCurMonthBill:
-      method: post
-      resourcePath: /api/v2/getCurMonthBill
-      description: "지난달 대비 이번달 비용을 확인합니다."
-    GetBillAsset:
-      method: post
-      resourcePath: /api/v2/getBillAsset
-      description: "이번달 사용한 리소스의 unit과 비용을 확인합니다."
-    GetWorkspaces:
-      method: get
-      resourcePath: /api/v2/getWorkspaces
-      description: "워크스페이스 목록을 조회합니다."
     GetCostReadyz:
       method: get
       resourcePath: /api/costopti/be/readyz
       description: "mc-cost-optimizer 헬스체크."
-
+    GetProjects:
+      method: get
+      resourcePath: /api/v2/getProjects
+      description: 워크스페이스에 속한 프로젝트 목록을 조회합니다.
+    GetUnusedRec:
+      method: post
+      resourcePath: /api/v2/opti/unusedRec
+      description: 이번달 CSP별 요약된 빌링 인보이스를 확인한다.
+    GetSummary:
+      method: post
+      resourcePath: /api/v2/invoice/getSummary
+      description: CSP별 빌링 인보이스 비용을 날짜별로 확인한다.
+    GetInvoice:
+      method: post
+      resourcePath: /api/v2/invoice/getInvoice
+      description: 이번달 빌링 인보이스 내역을 확인한다.
+    GetBillingBaseInfo:
+      method: post
+      resourcePath: /api/v2/invoice/getBillingBaseInfo
+      description: 이번달 CSP별 요약된 빌링 인보이스를 확인한다.
+    GetTop5Bill:
+      method: post
+      resourcePath: /api/v2/getTop5Bill
+      description: 이번달에 사용한 비용 상위 5개의 리소스와 비용을 확인합니다.
+    GetCurMonthBill:
+      method: post
+      resourcePath: /api/v2/getCurMonthBill
+      description: 지난달 대비 이번달 비용을 확인합니다.
+    GetBillAsset:
+      method: post
+      resourcePath: /api/v2/getBillAsset
+      description: 이번달 사용한 리소스의 unit과 비용을 확인합니다.
+    GetWorkspaces:
+      method: get
+      resourcePath: /api/v2/getWorkspaces
+      description: 워크스페이스 목록을 조회합니다.
   mc-data-manager:
+    GetDataMgrReadyz:
+      method: get
+      resourcePath: /readyz
+      description: "mc-data-manager 헬스체크."
     GenerateWindows:
       method: post
       resourcePath: /generate/windows
-      description: "Generate test data on on-premise Windows."
+      description: Generate test data on on-premise Windows.
     MigrationDynamodbFirestore:
       method: post
       resourcePath: /migration/dynamodb/firestore
-      description: "Migrate data stored in AWS DynamoDB to Google Cloud Firestore."
+      description: Migrate data stored in AWS DynamoDB to Google Cloud Firestore.
     MigrationLinuxNcp:
       method: post
       resourcePath: /migration/linux/ncp
-      description: "Migrate data stored in a Linux-based system to NCP Object Storage."
+      description: Migrate data stored in a Linux-based system to NCP Object Storage.
     MigrationNcpLinux:
       method: post
       resourcePath: /migration/ncp/linux
-      description: "Migrate data stored in NCP Object Storage to a Linux-based system."
+      description: Migrate data stored in NCP Object Storage to a Linux-based system.
     MigrationNcpWindows:
       method: post
       resourcePath: /migration/ncp/windows
-      description: "Migrate data stored in NCP Object Storage to a Windows-based system."
+      description: Migrate data stored in NCP Object Storage to a Windows-based system.
     MigrationGcpWindows:
       method: post
       resourcePath: /migration/gcp/windows
-      description: "Migrate data stored in GCP Cloud Storage to a Windows-based system."
+      description: Migrate data stored in GCP Cloud Storage to a Windows-based system.
     MigrationLinuxS3:
       method: post
       resourcePath: /migration/linux/s3
-      description: "Migrate data stored in a Linux-based system to AWS S3."
+      description: Migrate data stored in a Linux-based system to AWS S3.
     MigrationNcpS3:
       method: post
       resourcePath: /migration/ncp/s3
-      description: "Migrate data stored in NCP Object Storage to AWS S3."
+      description: Migrate data stored in NCP Object Storage to AWS S3.
     MigrationS3Windows:
       method: post
       resourcePath: /migration/s3/windows
-      description: "Migrate data stored in AWS S3 to a Windows-based system."
+      description: Migrate data stored in AWS S3 to a Windows-based system.
     GenerateDynamodb:
       method: post
       resourcePath: /generate/dynamodb
-      description: "Generate test data on AWS DynamoDB."
+      description: Generate test data on AWS DynamoDB.
     MigrationDynamodbMongodb:
       method: post
       resourcePath: /migration/dynamodb/mongodb
-      description: "Migrate data stored in AWS DynamoDB to Naver Cloud MongoDB."
+      description: Migrate data stored in AWS DynamoDB to Naver Cloud MongoDB.
     MigrationLinuxGcp:
       method: post
       resourcePath: /migration/linux/gcp
-      description: "Migrate data stored in a Linux-based system to GCP Cloud Storage."
+      description: Migrate data stored in a Linux-based system to GCP Cloud Storage.
     MigrationMysql:
       method: post
       resourcePath: /migration/mysql
-      description: "Migrate data from one MySQL database to another MySQL database."
+      description: Migrate data from one MySQL database to another MySQL database.
     MigrationWindowsS3:
       method: post
       resourcePath: /migration/windows/s3
-      description: "Migrate data stored in a Windows-based system to AWS S3."
+      description: Migrate data stored in a Windows-based system to AWS S3.
     GenerateFirestore:
       method: post
       resourcePath: /generate/firestore
-      description: "Generate test data on GCP Firestore."
+      description: Generate test data on GCP Firestore.
     GenerateMongodb:
       method: post
       resourcePath: /generate/mongodb
-      description: "Generate test data on NCP MongoDB."
+      description: Generate test data on NCP MongoDB.
     MigrationFirestoreMongodb:
       method: post
       resourcePath: /migration/firestore/mongodb
-      description: "Migrate data stored in Google Cloud Firestore to Naver Cloud MongoDB."
+      description: Migrate data stored in Google Cloud Firestore to Naver Cloud MongoDB.
     MigrationS3Linux:
       method: post
       resourcePath: /migration/s3/linux
-      description: "Migrate data stored in AWS S3 to a Linux-based system."
+      description: Migrate data stored in AWS S3 to a Linux-based system.
     GenerateGcp:
       method: post
       resourcePath: /generate/gcp
-      description: "Generate test data on GCP Cloud Storage."
+      description: Generate test data on GCP Cloud Storage.
     GenerateMysql:
       method: post
       resourcePath: /generate/mysql
-      description: "Generate test data on MySQL."
+      description: Generate test data on MySQL.
     MigrationFirestoreDynamodb:
       method: post
       resourcePath: /migration/firestore/dynamodb
-      description: "Migrate data stored in Google Cloud Firestore to AWS DynamoDB."
+      description: Migrate data stored in Google Cloud Firestore to AWS DynamoDB.
     MigrationGcpNcp:
       method: post
       resourcePath: /migration/gcp/ncp
-      description: "Migrate data stored in GCP Cloud Storage to NCP Object Storage."
+      description: Migrate data stored in GCP Cloud Storage to NCP Object Storage.
     MigrationNcpGcp:
       method: post
       resourcePath: /migration/ncp/gcp
-      description: "Migrate data stored in NCP Object Storage to GCP Cloud Storage."
+      description: Migrate data stored in NCP Object Storage to GCP Cloud Storage.
     GenerateLinux:
       method: post
       resourcePath: /generate/linux
-      description: "Generate test data on on-premise Linux."
+      description: Generate test data on on-premise Linux.
     GenerateNcp:
       method: post
       resourcePath: /generate/ncp
-      description: "Generate test data on NCP Object Storage."
+      description: Generate test data on NCP Object Storage.
     MigrationGcpS3:
       method: post
       resourcePath: /migration/gcp/s3
-      description: "Migrate data stored in GCP Cloud Storage to AWS S3."
+      description: Migrate data stored in GCP Cloud Storage to AWS S3.
     MigrationMongodbDynamodb:
       method: post
       resourcePath: /migration/mongodb/dynamodb
-      description: "Migrate data stored in Naver Cloud MongoDB to AWS DynamoDB."
+      description: Migrate data stored in Naver Cloud MongoDB to AWS DynamoDB.
     GenerateS3:
       method: post
       resourcePath: /generate/s3
-      description: "Generate test data on AWS S3."
+      description: Generate test data on AWS S3.
     MigrationS3Gcp:
       method: post
       resourcePath: /migration/s3/gcp
-      description: "Migrate data stored in AWS S3 to Google Cloud Storage."
+      description: Migrate data stored in AWS S3 to Google Cloud Storage.
     MigrationS3Ncp:
       method: post
       resourcePath: /migration/s3/ncp
-      description: "Migrate data stored in AWS S3 to Naver Cloud Object Storage."
+      description: Migrate data stored in AWS S3 to Naver Cloud Object Storage.
     MigrationGcpLinux:
       method: post
       resourcePath: /migration/gcp/linux
-      description: "Migrate data stored in GCP Cloud Storage to a Linux-based system."
+      description: Migrate data stored in GCP Cloud Storage to a Linux-based system.
     MigrationMongodbFirestore:
       method: post
       resourcePath: /migration/mongodb/firestore
-      description: "Migrate data stored in Naver Cloud MongoDB to Google Cloud Firestore."
+      description: Migrate data stored in Naver Cloud MongoDB to Google Cloud Firestore.
     MigrationWindowsGcp:
       method: post
       resourcePath: /migration/windows/gcp
-      description: "Migrate data stored in a Windows-based system to GCP Cloud Storage."
+      description: Migrate data stored in a Windows-based system to GCP Cloud Storage.
     MigrationWindowsNcp:
       method: post
       resourcePath: /migration/windows/ncp
-      description: "Migrate data stored in a Windows-based system to NCP Object Storage."
+      description: Migrate data stored in a Windows-based system to NCP Object Storage.

--- a/conf/docker/api.yaml
+++ b/conf/docker/api.yaml
@@ -85,139 +85,139 @@ serviceActions:
     Remove-Nodegroup:
       method: delete
       resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}
-      description: "Remove an existing Node Group from a Cluster."
+      description: Remove an existing Node Group from a Cluster.
     List-Connection-Configs:
       method: get
       resourcePath: /connectionconfig
-      description: "Retrieve a list of registered Connection Configs."
+      description: Retrieve a list of registered Connection Configs.
     Create-Connection-Config:
       method: post
       resourcePath: /connectionconfig
-      description: "Create a new Connection Config. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-cloud-connection-configuration-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+      description: Create a new Connection Config. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-cloud-connection-configuration-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]
     Count-Subnets-By-Connection:
       method: get
       resourcePath: /countsubnet/{ConnectionName}
-      description: "Get the total number of Subnets for a specific connection."
+      description: Get the total number of Subnets for a specific connection.
     Count-Vpcs-By-Connection:
       method: get
       resourcePath: /countvpc/{ConnectionName}
-      description: "Get the total number of VPCs for a specific connection."
+      description: Get the total number of VPCs for a specific connection.
     Upload-Cloud-Driver:
       method: post
       resourcePath: /driver/upload
-      description: "Upload a Cloud Driver library file."
+      description: Upload a Cloud Driver library file.
     Health-Check-Readyz:
       method: get
       resourcePath: /readyz
-      description: "Checks the health of CB-Spider service and its dependencies via /readyz endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+      description: Checks the health of CB-Spider service and its dependencies via /readyz endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]
     Unregister-Subnet:
       method: delete
       resourcePath: /regsubnet/{Name}
-      description: "Unregister a Subnet from a specified VPC."
+      description: Unregister a Subnet from a specified VPC.
     Get-Vm-Status:
       method: get
       resourcePath: /vmstatus/{Name}
-      description: "Retrieve the status of a specific Virtual Machine (VM)."
+      description: Retrieve the status of a specific Virtual Machine (VM).
     List-All-Vpc:
       method: get
       resourcePath: /allvpc
-      description: "Retrieve a comprehensive list of all Virtual Private Clouds (VPCs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Virtual Private Clouds (VPCs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Any-Call:
       method: post
       resourcePath: /anycall
-      description: "Execute a custom function (FID) with key-value parameters through AnyCall. 🕷️ [[Development Guide](https://github.com/cloud-barista/cb-spider/wiki/AnyCall-API-Extension-Guide)]"
+      description: Execute a custom function (FID) with key-value parameters through AnyCall. 🕷️ [[Development Guide](https://github.com/cloud-barista/cb-spider/wiki/AnyCall-API-Extension-Guide)]
     Get-Credential:
       method: get
       resourcePath: /credential/{CredentialName}
-      description: "Retrieve details of a specific Credential."
+      description: Retrieve details of a specific Credential.
     Unregister-Credential:
       method: delete
       resourcePath: /credential/{CredentialName}
-      description: "Unregister a specific Credential."
+      description: Unregister a specific Credential.
     Get-Disk:
       method: get
       resourcePath: /disk/{Name}
-      description: "Retrieve details of a specific Disk."
+      description: Retrieve details of a specific Disk.
     Delete-Disk:
       method: delete
       resourcePath: /disk/{Name}
-      description: "Delete a specified Disk."
+      description: Delete a specified Disk.
     List-Product-Family:
       method: get
       resourcePath: /productfamily/{RegionName}
-      description: "Retrieve a list of Product Families associated with a specific connection and region. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Price-Info-and-Cloud-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/RestAPI-Multi%E2%80%90Cloud-Price-Information-Guide)]"
+      description: Retrieve a list of Product Families associated with a specific connection and region. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Price-Info-and-Cloud-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/RestAPI-Multi%E2%80%90Cloud-Price-Information-Guide)]
     Get-Region:
       method: get
       resourcePath: /region/{RegionName}
-      description: "Retrieve details of a specific Region."
+      description: Retrieve details of a specific Region.
     Unregister-Region:
       method: delete
       resourcePath: /region/{RegionName}
-      description: "Unregister a specific Region."
+      description: Unregister a specific Region.
     Remove-Csp-Subnet:
       method: delete
       resourcePath: /vpc/{VPCName}/cspsubnet/{Id}
-      description: "Remove an existing CSP Subnet from a VPC."
+      description: Remove an existing CSP Subnet from a VPC.
     List-All-Vm:
       method: get
       resourcePath: /allvm
-      description: "Retrieve a comprehensive list of all Virtual Machines (VMs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Virtual Machines (VMs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Get-Myimage:
       method: get
       resourcePath: /myimage/{Name}
-      description: "Retrieve details of a specific MyImage."
+      description: Retrieve details of a specific MyImage.
     Delete-Myimage:
       method: delete
       resourcePath: /myimage/{Name}
-      description: "Delete a specified MyImage."
+      description: Delete a specified MyImage.
     Count-All-Clusters:
       method: get
       resourcePath: /countcluster
-      description: "Get the total number of Clusters across all connections."
+      description: Get the total number of Clusters across all connections.
     Count-All-Subnets:
       method: get
       resourcePath: /countsubnet
-      description: "Get the total number of Subnets across all connections."
+      description: Get the total number of Subnets across all connections.
     Get-Image:
       method: get
       resourcePath: /vmimage/{Name}
-      description: "Retrieve details of a specific Public Image. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
+      description: Retrieve details of a specific Public Image. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]
     Remove-Subnet:
       method: delete
       resourcePath: /vpc/{VPCName}/subnet/{SubnetName}
-      description: "Remove an existing Subnet from a VPC."
+      description: Remove an existing Subnet from a VPC.
     List-All-Cluster:
       method: get
       resourcePath: /allcluster
-      description: "Retrieve a comprehensive list of all Clusters associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Clusters associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Upgrade-Cluster:
       method: put
       resourcePath: /cluster/{Name}/upgrade
-      description: "Upgrade a Cluster to a specified version."
+      description: Upgrade a Cluster to a specified version.
     Count-Clusters-By-Connection:
       method: get
       resourcePath: /countcluster/{ConnectionName}
-      description: "Get the total number of Clusters for a specific connection."
+      description: Get the total number of Clusters for a specific connection.
     Count-All-Nlbs:
       method: get
       resourcePath: /countnlb
-      description: "Get the total number of Network Load Balancers (NLBs) across all connections."
+      description: Get the total number of Network Load Balancers (NLBs) across all connections.
     Attach-Disk:
       method: put
       resourcePath: /disk/{Name}/attach
-      description: "Attach an existing Disk to a VM."
+      description: Attach an existing Disk to a VM.
     Get-Cluster-Owner-Vpc:
       method: post
       resourcePath: /getclusterowner
-      description: "Retrieve the owner VPC of a specified Cluster."
+      description: Retrieve the owner VPC of a specified Cluster.
     Count-Vms-By-Connection:
       method: get
       resourcePath: /countvm/{ConnectionName}
-      description: "Get the total number of Virtual Machines (VMs) for a specific connection."
+      description: Get the total number of Virtual Machines (VMs) for a specific connection.
     Get-Region-Zone-Preconfig:
       method: get
       resourcePath: /preconfig/regionzone/{Name}
-      description: "Retrieve details of a specific pre-configured Region Zone based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+      description: Retrieve details of a specific pre-configured Region Zone based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]
     Get-Price-Info:
       method: post
       resourcePath: /priceinfo/{ProductFamily}/{RegionName}
@@ -225,772 +225,460 @@ serviceActions:
     Register-Vm:
       method: post
       resourcePath: /regvm
-      description: "Register a new Virtual Machine (VM) with the specified name and CSP ID."
+      description: Register a new Virtual Machine (VM) with the specified name and CSP ID.
     List-Key:
       method: get
       resourcePath: /keypair
-      description: "Retrieve a list of KeyPairs associated with a specific connection."
+      description: Retrieve a list of KeyPairs associated with a specific connection.
     Create-Key:
       method: post
       resourcePath: /keypair
-      description: "Create a new KeyPair with the specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#5-vm-keypair-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+      description: Create a new KeyPair with the specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#5-vm-keypair-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]
     Unregister-Vm:
       method: delete
       resourcePath: /regvm/{Name}
-      description: "Unregister a Virtual Machine (VM) with the specified name."
+      description: Unregister a Virtual Machine (VM) with the specified name.
     List-All-Securitygroups:
       method: get
       resourcePath: /allsecuritygroup
-      description: "Retrieve a comprehensive list of all Security Groups associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Security Groups associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Delete-Csp-Securitygroup:
       method: delete
       resourcePath: /cspsecuritygroup/{Id}
-      description: "Delete a specified CSP Security Group."
+      description: Delete a specified CSP Security Group.
     List-Preconfigured-Original-Org-Region:
       method: get
       resourcePath: /preconfig/orgregion
-      description: "Retrieve a list of pre-configured Original Regions based on driver and credential names. <br> The response structure may vary depending on the request DriverName and CredentialName."
+      description: Retrieve a list of pre-configured Original Regions based on driver and credential names. <br> The response structure may vary depending on the request DriverName and CredentialName.
     Unregister-Vpc:
       method: delete
       resourcePath: /regvpc/{Name}
-      description: "Unregister a VPC with the specified name."
+      description: Unregister a VPC with the specified name.
     List-Org-Vm-Spec:
       method: get
       resourcePath: /vmorgspec
-      description: "Retrieve a list of Original VM Specs associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName."
+      description: Retrieve a list of Original VM Specs associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName.
     Get-Org-Vm-Spec:
       method: get
       resourcePath: /vmorgspec/{Name}
-      description: "Retrieve details of a specific Original VM Spec."
+      description: Retrieve details of a specific Original VM Spec.
     List-All-Key:
       method: get
       resourcePath: /allkeypair
-      description: "Retrieve a comprehensive list of all KeyPairs associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all KeyPairs associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Get-Region-Zone:
       method: get
       resourcePath: /regionzone/{Name}
-      description: "Retrieve details of a specific Region Zone. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+      description: Retrieve details of a specific Region Zone. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]
     Add-Rules-Securitygroup:
       method: post
       resourcePath: /securitygroup/{SGName}/rules
-      description: "Add new rules to a Security Group."
+      description: Add new rules to a Security Group.
     Remove-Rules-Securitygroup:
       method: delete
       resourcePath: /securitygroup/{SGName}/rules
-      description: "Remove existing rules from a Security Group."
+      description: Remove existing rules from a Security Group.
     Delete-Csp-Myimage:
       method: delete
       resourcePath: /cspmyimage/{Id}
-      description: "Delete a specified CSP MyImage."
+      description: Delete a specified CSP MyImage.
     Unregister-Myimage:
       method: delete
       resourcePath: /regmyimage/{Name}
-      description: "Unregister a MyImage with the specified name."
+      description: Unregister a MyImage with the specified name.
     Register-Nlb:
       method: post
       resourcePath: /regnlb
-      description: "Register a new Network Load Balancer (NLB) with the specified name and CSP ID."
+      description: Register a new Network Load Balancer (NLB) with the specified name and CSP ID.
     Get-Securitygroup:
       method: get
       resourcePath: /securitygroup/{Name}
-      description: "Retrieve details of a specific Security Group."
+      description: Retrieve details of a specific Security Group.
     Delete-Securitygroup:
       method: delete
       resourcePath: /securitygroup/{Name}
-      description: "Delete a specified Security Group."
+      description: Delete a specified Security Group.
     Terminate-Vm:
       method: delete
       resourcePath: /vm/{Name}
-      description: "Terminate a specified Virtual Machine (VM)."
+      description: Terminate a specified Virtual Machine (VM).
     Get-Vm:
       method: get
       resourcePath: /vm/{Name}
-      description: "Retrieve details of a specific Virtual Machine (VM)."
+      description: Retrieve details of a specific Virtual Machine (VM).
     Register-Subnet:
       method: post
       resourcePath: /regsubnet
-      description: "Register a new Subnet within a specified VPC."
+      description: Register a new Subnet within a specified VPC.
     Add-Subnet:
       method: post
       resourcePath: /vpc/{VPCName}/subnet
-      description: "Add a new Subnet to an existing VPC."
+      description: Add a new Subnet to an existing VPC.
     List-Cloudos:
       method: get
       resourcePath: /cloudos
-      description: "Retrieve a list of supported Cloud OS."
+      description: Retrieve a list of supported Cloud OS.
     Count-All-Keys:
       method: get
       resourcePath: /countkeypair
-      description: "Get the total number of KeyPairs across all connections."
+      description: Get the total number of KeyPairs across all connections.
     Count-Securitygroups-By-Connection:
       method: get
       resourcePath: /countsecuritygroup/{ConnectionName}
-      description: "Get the total number of Security Groups for a specific connection."
+      description: Get the total number of Security Groups for a specific connection.
     Health-Check-Ping:
       method: get
       resourcePath: /ping
-      description: "Checks the health of CB-Spider service and its dependencies via /ping endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+      description: Checks the health of CB-Spider service and its dependencies via /ping endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]
     List-Vm-Status:
       method: get
       resourcePath: /vmstatus
-      description: "Retrieve a list of statuses for Virtual Machines (VMs) associated with a specific connection."
+      description: Retrieve a list of statuses for Virtual Machines (VMs) associated with a specific connection.
     Count-Connections-By-Provider:
       method: get
       resourcePath: /countconnectionconfig/{ProviderName}
-      description: "Get the total number of connections for a specific provider."
+      description: Get the total number of connections for a specific provider.
     Delete-Csp-Cluster:
       method: delete
       resourcePath: /cspcluster/{Id}
-      description: "Delete a specified CSP Cluster."
+      description: Delete a specified CSP Cluster.
     Unregister-Cluster:
       method: delete
       resourcePath: /regcluster/{Name}
-      description: "Unregister a Cluster with the specified name."
+      description: Unregister a Cluster with the specified name.
     Register-Myimage:
       method: post
       resourcePath: /regmyimage
-      description: "Register a new MyImage with the specified name and CSP ID."
+      description: Register a new MyImage with the specified name and CSP ID.
     Unregister-Securitygroup:
       method: delete
       resourcePath: /regsecuritygroup/{Name}
-      description: "Unregister a Security Group with the specified name."
+      description: Unregister a Security Group with the specified name.
     Get-Vm-Spec:
       method: get
       resourcePath: /vmspec/{Name}
-      description: "Retrieve details of a specific VM spec. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
+      description: Retrieve details of a specific VM spec. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]
     List-Cluster:
       method: get
       resourcePath: /cluster
-      description: "Retrieve a list of Clusters associated with a specific connection."
+      description: Retrieve a list of Clusters associated with a specific connection.
     Create-Cluster:
       method: post
       resourcePath: /cluster
-      description: "Create a new Cluster with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Provider-Managed-Kubernetes-and-Driver-API)] <br> * NodeGroupList is optional, depends on CSP type: <br> &nbsp;- Type-I (e.g., Tencent, Alibaba): requires separate Node Group addition after Cluster creation. <br> &nbsp;- Type-II (e.g., Azure, NHN): mandates at least one Node Group during initial Cluster creation."
+      description: 'Create a new Cluster with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Provider-Managed-Kubernetes-and-Driver-API)] <br> * NodeGroupList is optional, depends on CSP type: <br> &nbsp;- Type-I (e.g., Tencent, Alibaba): requires separate Node Group addition after Cluster creation. <br> &nbsp;- Type-II (e.g., Azure, NHN): mandates at least one Node Group during initial Cluster creation.'
     Count-All-Myimages:
       method: get
       resourcePath: /countmyimage
-      description: "Get the total number of MyImages across all connections."
+      description: Get the total number of MyImages across all connections.
     Detach-Disk:
       method: put
       resourcePath: /disk/{Name}/detach
-      description: "Detach an existing Disk from a VM."
+      description: Detach an existing Disk from a VM.
     List-Cloud-Drivers:
       method: get
       resourcePath: /driver
-      description: "Retrieve a list of registered Cloud Drivers."
+      description: Retrieve a list of registered Cloud Drivers.
     Register-Cloud-Driver:
       method: post
       resourcePath: /driver
-      description: "Register a new Cloud Driver. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#1-cloud-driver-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+      description: Register a new Cloud Driver. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#1-cloud-driver-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]
     List-Nlb:
       method: get
       resourcePath: /nlb
-      description: "Retrieve a list of Network Load Balancers (NLBs) associated with a specific connection."
+      description: Retrieve a list of Network Load Balancers (NLBs) associated with a specific connection.
     Create-Nlb:
       method: post
       resourcePath: /nlb
-      description: "Create a new Network Load Balancer (NLB) with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Network-Load-Balancer-and-Driver-API)]"
+      description: Create a new Network Load Balancer (NLB) with specified configurations. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Network-Load-Balancer-and-Driver-API)]
     List-Org-Zone:
       method: get
       resourcePath: /orgzone
-      description: "Retrieve a list of Original Zones associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName."
+      description: Retrieve a list of Original Zones associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName.
     Health-Check-Healthcheck:
       method: get
       resourcePath: /healthcheck
-      description: "Checks the health of CB-Spider service and its dependencies via /healthcheck endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+      description: Checks the health of CB-Spider service and its dependencies via /healthcheck endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]
     Delete-Key:
       method: delete
       resourcePath: /keypair/{Name}
-      description: "Delete a specified KeyPair."
+      description: Delete a specified KeyPair.
     Get-Key:
       method: get
       resourcePath: /keypair/{Name}
-      description: "Retrieve details of a specific KeyPair."
+      description: Retrieve details of a specific KeyPair.
     List-Image:
       method: get
       resourcePath: /vmimage
-      description: "Retrieve a list of Public Images associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]"
+      description: Retrieve a list of Public Images associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/How-to-get-Image-List-with-REST-API)]
     Get-Cluster:
       method: get
       resourcePath: /cluster/{Name}
-      description: "Retrieve details of a specific Cluster."
+      description: Retrieve details of a specific Cluster.
     Delete-Cluster:
       method: delete
       resourcePath: /cluster/{Name}
-      description: "Delete a specified Cluster."
+      description: Delete a specified Cluster.
     Get-Csp-Vm:
       method: get
       resourcePath: /cspvm/{Id}
-      description: "Retrieve details of a specific CSP Virtual Machine (VM)."
+      description: Retrieve details of a specific CSP Virtual Machine (VM).
     Terminate-Csp-Vm:
       method: delete
       resourcePath: /cspvm/{Id}
-      description: "Terminate a specified CSP Virtual Machine (VM)."
+      description: Terminate a specified CSP Virtual Machine (VM).
     Health-Check-Health:
       method: get
       resourcePath: /health
-      description: "Checks the health of CB-Spider service and its dependencies via /health endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]"
+      description: Checks the health of CB-Spider service and its dependencies via /health endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]
     Register-Vpc:
       method: post
       resourcePath: /regvpc
-      description: "Register a new Virtual Private Cloud (VPC) with the specified name and CSP ID."
+      description: Register a new Virtual Private Cloud (VPC) with the specified name and CSP ID.
     Unregister-Nlb:
       method: delete
       resourcePath: /regnlb/{Name}
-      description: "Unregister a Network Load Balancer (NLB) with the specified name."
+      description: Unregister a Network Load Balancer (NLB) with the specified name.
     Get-Sg-Owner-Vpc:
       method: post
       resourcePath: /getsecuritygroupowner
-      description: "Retrieve the owner VPC of a specified Security Group."
+      description: Retrieve the owner VPC of a specified Security Group.
     Create-Vpc:
       method: post
       resourcePath: /vpc
-      description: "Create a new Virtual Private Cloud (VPC) with specified subnet configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-vpcsubnet-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+      description: Create a new Virtual Private Cloud (VPC) with specified subnet configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-vpcsubnet-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]
     List-Vpc:
       method: get
       resourcePath: /vpc
-      description: "Retrieve a list of Virtual Private Clouds (VPCs) associated with a specific connection."
+      description: Retrieve a list of Virtual Private Clouds (VPCs) associated with a specific connection.
     Control-Vm:
       method: put
       resourcePath: /controlvm/{Name}
-      description: "Control the state of a Virtual Machine (VM) such as suspend, resume, or reboot."
+      description: Control the state of a Virtual Machine (VM) such as suspend, resume, or reboot.
     List-All-Myimage:
       method: get
       resourcePath: /allmyimage
-      description: "Retrieve a comprehensive list of all MyImages associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all MyImages associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Count-Disks-By-Connection:
       method: get
       resourcePath: /countdisk/{ConnectionName}
-      description: "Get the total number of Disks for a specific connection."
+      description: Get the total number of Disks for a specific connection.
     List-Credentials:
       method: get
       resourcePath: /credential
-      description: "Retrieve a list of registered Credentials."
+      description: Retrieve a list of registered Credentials.
     Register-Credential:
       method: post
       resourcePath: /credential
-      description: "Register a new Credential. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-cloud-credential-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+      description: Register a new Credential. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-cloud-credential-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]
     Delete-Csp-Disk:
       method: delete
       resourcePath: /cspdisk/{Id}
-      description: "Delete a specified CSP Disk."
+      description: Delete a specified CSP Disk.
     Register-Key:
       method: post
       resourcePath: /regkeypair
-      description: "Register a new KeyPair with the specified name and CSP ID."
+      description: Register a new KeyPair with the specified name and CSP ID.
     List-All-Nlb:
       method: get
       resourcePath: /allnlb
-      description: "Retrieve a comprehensive list of all Network Load Balancers (NLBs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Network Load Balancers (NLBs) associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Set-Nodegroup-Autoscaling:
       method: put
       resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/onautoscaling
-      description: "Enable or disable auto scaling for a Node Group in a Cluster."
+      description: Enable or disable auto scaling for a Node Group in a Cluster.
     List-Vm-Spec:
       method: get
       resourcePath: /vmspec
-      description: "Retrieve a list of VM specs associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]"
+      description: Retrieve a list of VM specs associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-vm-spec-%EC%A0%95%EB%B3%B4-%EC%A0%9C%EA%B3%B5)]
     Count-All-Disks:
       method: get
       resourcePath: /countdisk
-      description: "Get the total number of Disks across all connections."
+      description: Get the total number of Disks across all connections.
     Register-Cluster:
       method: post
       resourcePath: /regcluster
-      description: "Register a new Cluster with the specified VPC and CSP ID."
+      description: Register a new Cluster with the specified VPC and CSP ID.
     Register-Securitygroup:
       method: post
       resourcePath: /regsecuritygroup
-      description: "Register a new Security Group with the specified name and CSP ID."
+      description: Register a new Security Group with the specified name and CSP ID.
     Get-Vpc:
       method: get
       resourcePath: /vpc/{Name}
-      description: "Retrieve details of a specific Virtual Private Cloud (VPC)."
+      description: Retrieve details of a specific Virtual Private Cloud (VPC).
     Delete-Vpc:
       method: delete
       resourcePath: /vpc/{Name}
-      description: "Delete a specified Virtual Private Cloud (VPC)."
+      description: Delete a specified Virtual Private Cloud (VPC).
     Get-Connection-Config:
       method: get
       resourcePath: /connectionconfig/{ConfigName}
-      description: "Retrieve details of a specific Connection Config."
+      description: Retrieve details of a specific Connection Config.
     Delete-Connection-Config:
       method: delete
       resourcePath: /connectionconfig/{ConfigName}
-      description: "Delete a specific Connection Config."
+      description: Delete a specific Connection Config.
     Get-Cloud-Driver:
       method: get
       resourcePath: /driver/{DriverName}
-      description: "Retrieve details of a specific Cloud Driver."
+      description: Retrieve details of a specific Cloud Driver.
     Unregister-Cloud-Driver:
       method: delete
       resourcePath: /driver/{DriverName}
-      description: "Unregister a specific Cloud Driver."
+      description: Unregister a specific Cloud Driver.
     Count-Nlbs-By-Connection:
       method: get
       resourcePath: /countnlb/{ConnectionName}
-      description: "Get the total number of Network Load Balancers (NLBs) for a specific connection."
+      description: Get the total number of Network Load Balancers (NLBs) for a specific connection.
     Delete-Nlb:
       method: delete
       resourcePath: /nlb/{Name}
-      description: "Delete a specified Network Load Balancer (NLB)."
+      description: Delete a specified Network Load Balancer (NLB).
     Get-Nlb:
       method: get
       resourcePath: /nlb/{Name}
-      description: "Retrieve details of a specific Network Load Balancer (NLB)."
+      description: Retrieve details of a specific Network Load Balancer (NLB).
     Add-Nlb-Vms:
       method: post
       resourcePath: /nlb/{Name}/vms
-      description: "Add a new set of VMs to an existing Network Load Balancer (NLB)."
+      description: Add a new set of VMs to an existing Network Load Balancer (NLB).
     Remove-Nlb-Vms:
       method: delete
       resourcePath: /nlb/{Name}/vms
-      description: "Remove a set of VMs from an existing Network Load Balancer (NLB)."
+      description: Remove a set of VMs from an existing Network Load Balancer (NLB).
     List-Org-Region:
       method: get
       resourcePath: /orgregion
-      description: "Retrieve a list of Original Regions associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName."
+      description: Retrieve a list of Original Regions associated with a specific connection. <br> The response structure may vary depending on the request ConnectionName.
     Count-All-Vms:
       method: get
       resourcePath: /countvm
-      description: "Get the total number of Virtual Machines (VMs) across all connections."
+      description: Get the total number of Virtual Machines (VMs) across all connections.
     Count-All-Vpcs:
       method: get
       resourcePath: /countvpc
-      description: "Get the total number of VPCs across all connections."
+      description: Get the total number of VPCs across all connections.
     Delete-Csp-Key:
       method: delete
       resourcePath: /cspkeypair/{Id}
-      description: "Delete a specified CSP KeyPair."
+      description: Delete a specified CSP KeyPair.
     Register-Disk:
       method: post
       resourcePath: /regdisk
-      description: "Register a new Disk with the specified name, zone, and CSP ID."
+      description: Register a new Disk with the specified name, zone, and CSP ID.
     Count-All-Securitygroups:
       method: get
       resourcePath: /countsecuritygroup
-      description: "Get the total number of Security Groups across all connections."
+      description: Get the total number of Security Groups across all connections.
     Delete-Csp-Vpc:
       method: delete
       resourcePath: /cspvpc/{Id}
-      description: "Delete a specified CSP Virtual Private Cloud (VPC)."
+      description: Delete a specified CSP Virtual Private Cloud (VPC).
     Get-Nlb-Owner-Vpc:
       method: post
       resourcePath: /getnlbowner
-      description: "Retrieve the owner VPC of a specified Network Load Balancer (NLB)."
+      description: Retrieve the owner VPC of a specified Network Load Balancer (NLB).
     Get-Vmgroup-Healthinfo:
       method: get
       resourcePath: /nlb/{Name}/health
-      description: "Retrieve the health information of the VM group in a specified Network Load Balancer (NLB)."
+      description: Retrieve the health information of the VM group in a specified Network Load Balancer (NLB).
     List-Regions:
       method: get
       resourcePath: /region
-      description: "Retrieve a list of registered Regions."
+      description: Retrieve a list of registered Regions.
     Register-Region:
       method: post
       resourcePath: /region
-      description: "Register a new Region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-cloud-regionzone-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+      description: Register a new Region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-cloud-regionzone-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]
     Create-Securitygroup:
       method: post
       resourcePath: /securitygroup
-      description: "Create a new Security Group with specified rules and tags. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Security-Group-Rules-and-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-securitygroup-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]"
+      description: Create a new Security Group with specified rules and tags. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Security-Group-Rules-and-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#4-securitygroup-%EC%83%9D%EC%84%B1-%EB%B0%8F-%EC%A0%9C%EC%96%B4)]
     List-Securitygroup:
       method: get
       resourcePath: /securitygroup
-      description: "Retrieve a list of Security Groups associated with a specific connection."
+      description: Retrieve a list of Security Groups associated with a specific connection.
     List-All-Disk:
       method: get
       resourcePath: /alldisk
-      description: "Retrieve a comprehensive list of all Disks associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+      description: Retrieve a comprehensive list of all Disks associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
     Add-Nodegroup:
       method: post
       resourcePath: /cluster/{Name}/nodegroup
-      description: "Add a new Node Group to an existing Cluster."
+      description: Add a new Node Group to an existing Cluster.
     List-Disk:
       method: get
       resourcePath: /disk
-      description: "Retrieve a list of Disks associated with a specific connection."
+      description: Retrieve a list of Disks associated with a specific connection.
     Create-Disk:
       method: post
       resourcePath: /disk
-      description: "Create a new Disk with the specified configuration. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Disk-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+      description: Create a new Disk with the specified configuration. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Disk-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]
     List-Region-Zone-Preconfig:
       method: get
       resourcePath: /preconfig/regionzone
-      description: "Retrieve a list of pre-configured Region Zones based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+      description: Retrieve a list of pre-configured Region Zones based on driver and credential names. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]
     Delete-Csp-Nlb:
       method: delete
       resourcePath: /cspnlb/{Id}
-      description: "Delete a specified CSP Network Load Balancer (NLB)."
+      description: Delete a specified CSP Network Load Balancer (NLB).
     List-Region-Zone:
       method: get
       resourcePath: /regionzone
-      description: "Retrieve a list of Region Zones associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]"
+      description: Retrieve a list of Region Zones associated with a specific connection. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/REST-API-Region-Zone-Information-Guide)]
     Count-All-Connections:
       method: get
       resourcePath: /countconnectionconfig
-      description: "Get the total number of connections."
+      description: Get the total number of connections.
     Count-Keys-By-Connection:
       method: get
       resourcePath: /countkeypair/{ConnectionName}
-      description: "Get the total number of KeyPairs for a specific connection."
+      description: Get the total number of KeyPairs for a specific connection.
     Increase-Disk-Size:
       method: put
       resourcePath: /disk/{Name}/size
-      description: "Increase the size of an existing disk."
+      description: Increase the size of an existing disk.
     Change-Nodegroup-Scaling:
       method: put
       resourcePath: /cluster/{Name}/nodegroup/{NodeGroupName}/autoscalesize
-      description: "Change the scaling settings for a Node Group in a Cluster."
+      description: Change the scaling settings for a Node Group in a Cluster.
     List-Myimage:
       method: get
       resourcePath: /myimage
-      description: "Retrieve a list of MyImages associated with a specific connection."
+      description: Retrieve a list of MyImages associated with a specific connection.
     Snapshot-Vm:
       method: post
       resourcePath: /myimage
-      description: "Create a new MyImage snapshot from a specified VM. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/MyImage-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+      description: Create a new MyImage snapshot from a specified VM. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/MyImage-and-Driver-API)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]
     Unregister-Key:
       method: delete
       resourcePath: /regkeypair/{Name}
-      description: "Unregister a KeyPair with the specified name."
+      description: Unregister a KeyPair with the specified name.
     Start-Vm:
       method: post
       resourcePath: /vm
-      description: "Start a new Virtual Machine (VM) with specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-%EB%A9%80%ED%8B%B0%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C-vm-%EC%9D%B8%ED%94%84%EB%9D%BC-%EC%9E%90%EC%9B%90-%EC%A0%9C%EC%96%B4multi-cloud-vm-infra-resource-control)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]"
+      description: Start a new Virtual Machine (VM) with specified configurations. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#2-%EB%A9%80%ED%8B%B0%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C-vm-%EC%9D%B8%ED%94%84%EB%9D%BC-%EC%9E%90%EC%9B%90-%EC%A0%9C%EC%96%B4multi-cloud-vm-infra-resource-control)], [[Snapshot-MyImage,Disk Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Snapshot,-MyImage-and-Disk-Overview)]
     List-Vm:
       method: get
       resourcePath: /vm
-      description: "Retrieve a list of Virtual Machines (VMs) associated with a specific connection."
+      description: Retrieve a list of Virtual Machines (VMs) associated with a specific connection.
     Get-Cloudos-Metainfo:
       method: get
       resourcePath: /cloudos/metainfo/{CloudOSName}
-      description: "Retrieve metadata information for a specific Cloud OS."
+      description: Retrieve metadata information for a specific Cloud OS.
     Count-Myimages-By-Connection:
       method: get
       resourcePath: /countmyimage/{ConnectionName}
-      description: "Get the total number of MyImages for a specific connection."
+      description: Get the total number of MyImages for a specific connection.
     Get-Vm-Using-Rs:
       method: get
       resourcePath: /getvmusingresources
-      description: "Retrieve details of a VM using resource ID."
+      description: Retrieve details of a VM using resource ID.
     Unregister-Disk:
       method: delete
       resourcePath: /regdisk/{Name}
-      description: "Unregister a Disk with the specified name."
-
+      description: Unregister a Disk with the specified name.
   mc-iam-manager:
-    Searchrolesbyname:
-      method: get
-      resourcePath: /api/role/name/{roleName}
-      description: "role 검색"
-    Logout:
-      method: post
-      resourcePath: /api/auth/logout
-      description: "AccessToken및 RefreshToken을 받아 해당 토큰 파기"
-    Deleteresourcepermissionpolicesbyoperationid:
-      method: delete
-      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}/remove
-      description: "권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다."
-    listProjects:
-      method: post
-      resourcePath: /api/projects/list
-      description: "project 목록 조회"
-    createProject:
-      method: post
-      resourcePath: /api/projects
-      description: "project 생성"
-    Getresources:
-      method: get
-      resourcePath: /api/resource
-      description: "리소스의 정보를 검색합니다."
-    Createresource:
-      method: post
-      resourcePath: /api/resource
-      description: "리소스를 생성합니다."
-    Getrolelist:
-      method: post
-      resourcePath: /api/roles/list
-      description: "role 전체 목록 조회"
-    Getrolescsproles:
-      method: get
-      resourcePath: /api/roles/csp-roles/id/{roleId}
-      description: "role별 CSP role 목록 조회"
-    listCSPRoles:
-      method: post
-      resourcePath: /api/roles/csp/list
-      description: "CSP에 정의된 역할 목록 조회"
-    Createrole:
-      method: post
-      resourcePath: /api/roles
-      description: "role 생성"
-    Updaterole:
-      method: put
-      resourcePath: /api/roles/id/{roleId}
-      description: "role 수정"
-    Syncrolelistwithkeycloak:
-      method: get
-      resourcePath: /api/tool/keycloak/role/sync
-      description: "연결된 TB(mcinframanager)의 NS 리스트를 Project List 로 등록.  \n  \n기존 등록된 project 와 중복이 발생하면 오류 발생. 새로운 환경에서 첫 회 실행하는 것을 추천."
-    Searchworkspacesbyname:
-      method: get
-      resourcePath: /api/ws/workspace/{workspaceName}
-      description: "workspace 검색"
-    Readyz:
-      method: get
-      resourcePath: /readyz
-      description: "mc-iam-manager가 정상적으로 작동중인지 단순 확인합니다."
-    Getwpmappinglistorderbyworkspace:
-      method: get
-      resourcePath: /api/wsprj
-      description: "workspace - projects mapping workspace 기준 모든 목록 조회"
-    Createwpmapping:
-      method: post
-      resourcePath: /api/wsprj
-      description: "workspace - projects mapping 생성"
-    addProjectToWorkspace:
-      method: post
-      resourcePath: /api/workspaces/assign/projects
-      description: "workspace에 project 등록"
-    Getworkspaceuserrolemappinglistbyworkspaceid:
-      method: get
-      resourcePath: /api/wsuserrole/workspace/id/{workspaceId}
-      description: "workspace - user - role mapping 목록 workspace 기준 조회"
-    Login:
-      method: post
-      resourcePath: /api/auth/login
-      description: "ID/Password를 받아 JWT 세션 토큰을 반환"
-    Gettokeninfo:
-      method: get
-      resourcePath: /api/auth/tokeninfo
-      description: "유저 정보 조회"
-    Getcurrentpermissioncsv:
-      method: get
-      resourcePath: /api/permission/file/framework/{framework}
-      description: "현재 권한을 CSV 형태로 가져옵니다."
-    Importpermissionbycsv:
-      method: post
-      resourcePath: /api/permission/file/framework/{framework}
-      description: "CSV 기반으로 권한을 업데이트 합니다."
-    Getprojectbyid:
-      method: get
-      resourcePath: /api/prj/project/id/{projectId}
-      description: "project 단건 조회"
-    Updateprojectbyid:
-      method: put
-      resourcePath: /api/prj/project/id/{projectId}
-      description: "project 수정"
-    Deleteprojectbyid:
-      method: delete
-      resourcePath: /api/prj/project/id/{projectId}
-      description: "project 삭제"
-    deleteWorkspace:
-      method: delete
-      resourcePath: /api/workspaces/id/{workspaceId}
-      description: "workspace 삭제"
-    getWorkspaceByID:
-      method: get
-      resourcePath: /api/workspaces/id/{workspaceId}
-      description: "workspace 단건 조회"
-    updateWorkspace:
-      method: put
-      resourcePath: /api/workspaces/id/{workspaceId}
-      description: "workspace 수정"
-    Getcerts:
-      method: get
-      resourcePath: /api/auth/certs
-      description: "유저 토큰의 사용가능 유무"
-    Authgetuservalidate:
-      method: get
-      resourcePath: /api/auth/validate
-      description: "유저 토큰의 사용가능 유무"
-    Getpermission:
-      method: get
-      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}
-      description: "권한을 검색합니다."
-    Updateresourcepermissionbyoperationid:
-      method: put
-      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}
-      description: "권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다."
-    Activeuser:
-      method: post
-      resourcePath: /api/user/active
-      description: "권한 있는 사용자가 해당 유저를 활성화합니다."
-    Getworkspaceuserrolemappinglistorderbyworkspace:
-      method: get
-      resourcePath: /api/wsuserrole
-      description: "workspace - user - role mapping 목록 workspace 기준 전체 조회"
-    Createworkspaceuserrolemappingbyname:
-      method: post
-      resourcePath: /api/wsuserrole
-      description: "workspace - user - role mapping 생성"
-    Getallavailablemenus:
-      method: post
-      resourcePath: /api/users/menus/list
-      description: "해당 프레임워크 사용자에게 할당된 메뉴 리스트를 반환합니다."
-    Getmappedmenusbyrolelist:
-      method: post
-      resourcePath: /api/menus/platform-roles/list
-      description: "해당 프레임워크 역할에 할당된 메뉴 리스트를 반환합니다."
-    Deleteuser:
-      method: delete
-      resourcePath: /api/users/id/{userId}
-      description: "사용자를 삭제합니다."
-    Updateuser:
-      method: put
-      resourcePath: /api/users/id/{userId}
-      description: "사용자 정보를 업데이트 합니다."
-    Createworkspace:
-      method: post
-      resourcePath: /api/workspaces
-      description: "workspace 생성"
-    listWorkspaces:
-      method: post
-      resourcePath: /api/workspaces/list
-      description: "workspace 목록 조회"
-    listMciamPermissions:
-      method: post
-      resourcePath: /api/permissions/mciam/list
-      description: "모든 권한을 가져옵니다."
-    listUsersAndRolesByWorkspaces:
-      method: post
-      resourcePath: /api/workspaces/id/{workspaceId}/users/list
-      description: "workspace 목록 조회"
-    getWorkspaceProjectsByWorkspaceId:
-      method: get
-      resourcePath: /api/workspaces/id/{workspaceId}/projects/list
-    ListUsersAndRolesByWorkspaces:
-      method: post
-      resourcePath: /api/workspaces/id/{workspaceId}/users/list
-    listWorkspaceProjects:
-      method: post
-      resourcePath: /api/workspaces/projects/list
-    getTempCredentialProviders:
-      method: get
-      resourcePath: /api/auth/temp-credential-csps
-      description: "임시 자격 증명을 지원하는 CSP 목록 조회"
-    Appendresourcepermissionpolicesbyoperationid:
-      method: put
-      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}/append
-      description: "권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다."
-    Updateresource:
-      method: put
-      resourcePath: /api/resource/id/{id}
-      description: "리소스를 업데이트 합니다."
-    Deleteresource:
-      method: delete
-      resourcePath: /api/resource/id/{id}
-      description: "리소스를 삭제합니다."
-    Getmenuresources:
-      method: post
-      # method: get
-      # resourcePath: /api/resource/menus
-      resourcePath: /api/menus/list
-      description: "메뉴 리소스를 검색합니다."
-    Getallpermissions:
-      method: get
-      resourcePath: /api/ticket
-      description: "사용자는 uma_protection Role 을 가져야 한다."
-    Getpermissionticket:
-      method: post
-      resourcePath: /api/ticket
-      description: "사용자는 uma_protection Role 을 가져야 한다."
-    getProjectsByWorkspaceId:
-      method: get
-      resourcePath: /api/workspaces/id/{workspaceId}/projects/list
-      description: "workspace - projects mapping workspace 기준 목록 조회"
-    listUserWorkspaces:
-      method: post
-      resourcePath: /api/users/workspaces/list
-      description: "workspace - user - role mapping 목록 user 기준 조회"
-    Deleteworkspaceuserrolemapping:
-      method: delete
-      resourcePath: /api/wsuserrole/workspace/id/{workspaceId}/user/id/{userId}
-      description: "workspace - user - role mapping 목록 workspace 와 user 로 mapping 삭제"
-    Loginrefresh:
-      method: post
-      resourcePath: /api/auth/refresh
-      description: "refresh_token과 기존 JWT를 받아, 새로운 JWT 토큰 발급"
-    Getuserinfo:
-      method: get
-      resourcePath: /api/auth/userinfo
-      description: "유저 정보 조회"
-    Updateuseinfonotuse:
-      method: put
-      resourcePath: /api/auth/userinfo
-      description: "유저 정보 조회"
-    Createapiresourcesbyapiyaml:
-      method: post
-      resourcePath: /api/resource/file/framework/{framework}
-      description: "mc-admin-cli 에서 생성한 api yaml을 바탕으로 모든 리소스를 등록합니다.  \n리소스가 중복될시 오류를 반환하고 업데이트 하지 않습니다."
-    Resetresource:
-      method: delete
-      resourcePath: /api/resource/reset
-      description: "모든 리소스를 삭제합니다."
-    Syncprojectlistwithmcinfra:
-      method: get
-      resourcePath: /api/tool/mcinfra/sync
-      description: "연결된 TB(mcinframanager)의 NS 리스트를 Project List 로 등록.  \n  \n기존 등록된 project 와 중복이 발생하면 오류 발생. 새로운 환경에서 첫 회 실행하는 것을 추천."
-    Getdependentpermissionsbypolicyid:
-      method: get
-      resourcePath: /api/permission/policyid/{policyid}
-      description: "권한을 검색합니다."
-    Searchprojectsbyname:
-      method: get
-      resourcePath: /api/prj/project/{projectName}
-      description: "project 목록 검색"
-    Resetmenuresource:
-      method: delete
-      resourcePath: /api/resource/reset/menu
-      description: "모든 메뉴 리소스를 삭제합니다."
-    Deleterolebyid:
-      method: delete
-      resourcePath: /api/roles/id/{roleId}
-      description: "role 삭제"
-    Getrolebyid:
-      method: get
-      resourcePath: /api/role/id/{roleId}
-      description: "role 단건 조회"
-    Updaterolebyid:
-      method: put
-      resourcePath: /api/role/id/{roleId}
-      description: "role 수정"
-    Getrolebypolicyidnotuse:
-      method: get
-      resourcePath: /api/role/policyid/{policyid}
-      description: "role 단건 조회"
-    Createmenuresourcesbymenuyaml:
-      method: post
-      resourcePath: /api/resource/file/framework/{framework}/menu
-      description: "mc-web-console 등 menu yaml을 사용해서 메뉴 리소스를 등록합니다."
-    Listusers:
-      method: post
-      resourcepath: /api/users/list
-      description: "사용자 목록 조회"
-    getUserByID:
-      method: get
-      resourcePath: /api/users/id/{userId}
-      description: "사용자 단건 조회 by id"
-    Getuserbyname:
-      method: get
-      resourcePath: /api/users/name/{username}
-      description: "사용자 단건 조회 by name"
-    Getuserworkspacesbyuserid:
-      method: get
-      resourcePath: /api/users/id/{userId}/workspaces/list
-      description: "특정 사용자의 워크스페이스 목록조회"
-    Createuser:
-      method: post
-      resourcePath: /api/users
-      description: "유저를 등록합니다."
-    Deactiveuser:
-      method: post
-      resourcePath: /api/user/deactive
-      description: "권한 있는 사용자가 해당 유저를 비활성화합니다."
-    removeWorkspaceFromProject:
-      method: delete
-      resourcePath: /api/projects/unassign/workspaces
-      description: "Workspace에서 Project 할당 해제"
     ListMcmpApisServices:
       method: post
       resourcePath: /api/mcmp-apis/list
@@ -1002,31 +690,47 @@ serviceActions:
     UpdateFrameworkService:
       method: put
       resourcePath: /api/mcmp-apis/name/{serviceName}
-      description: "프레임워크 서비스 BaseURL 수정."
-    mciamCheckHealth:
+      description: "프레임워크 서비스 BaseURL 수정. body: {BaseURL: string}"
+    Searchrolesbyname:
       method: get
-      resourcePath: /readyz
-      description: "mc-iam-manager 헬스체크."
-    assignPlatformRole:
+      resourcePath: /api/role/name/{roleName}
+      description: role 검색
+    Logout:
       method: post
-      resourcePath: /api/roles/assign/platform-role
-      description: "Platform Role 할당"
-    removePlatformRole:
+      resourcePath: /api/auth/logout
+      description: AccessToken및 RefreshToken을 받아 해당 토큰 파기
+    Deleteresourcepermissionpolicesbyoperationid:
       method: delete
-      resourcePath: /api/roles/unassign/platform-role
-      description: "사용자에게서 Platform Role 제거"
-    listPlatformRoles:
+      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}/remove
+      description: 권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다.
+    listProjects:
       method: post
-      resourcePath: /api/roles/platform-roles/list
-      description: "Platform Role 목록 조회"
-    AssignRoleToUser:
+      resourcePath: /api/projects/list
+      description: project 목록 조회
+    createProject:
       method: post
-      resourcePath: /api/roles/assign/platform-role
-      description: "사용자에게 플랫폼 역할을 할당합니다."
-    Signup:
+      resourcePath: /api/projects
+      description: project 생성
+    Getresources:
+      method: get
+      resourcePath: /api/resource
+      description: 리소스의 정보를 검색합니다.
+    Createresource:
       method: post
-      resourcePath: /api/auth/signup
-      description: "신규 사용자 회원가입 (관리자 승인 후 로그인 가능)"
+      resourcePath: /api/resource
+      description: 리소스를 생성합니다.
+    Getrolelist:
+      method: post
+      resourcePath: /api/roles/list
+      description: role 전체 목록 조회
+    Getrolescsproles:
+      method: get
+      resourcePath: /api/roles/csp-roles/id/{roleId}
+      description: role별 CSP role 목록 조회
+    listCSPRoles:
+      method: post
+      resourcePath: /api/roles/csp/list
+      description: "CSP에 정의된 역할 목록 조회"
     GetCspRoleById:
       method: get
       resourcePath: /api/roles/csp/id/{roleId}
@@ -1075,114 +779,399 @@ serviceActions:
       method: post
       resourcePath: /api/csp-policies/sync
       description: "CSP Policy 동기화"
+    Createrole:
+      method: post
+      resourcePath: /api/roles
+      description: role 생성
+    Updaterole:
+      method: put
+      resourcePath: /api/roles/id/{roleId}
+      description: role 수정
+    Syncrolelistwithkeycloak:
+      method: get
+      resourcePath: /api/tool/keycloak/role/sync
+      description: "연결된 TB(mcinframanager)의 NS 리스트를 Project List 로 등록.  \n  \n기존 등록된 project 와 중복이 발생하면 오류 발생. 새로운 환경에서 첫 회 실행하는 것을 추천."
+    Searchworkspacesbyname:
+      method: get
+      resourcePath: /api/ws/workspace/{workspaceName}
+      description: workspace 검색
+    Readyz:
+      method: get
+      resourcePath: /readyz
+      description: mc-iam-manager가 정상적으로 작동중인지 단순 확인합니다.
+    Getwpmappinglistorderbyworkspace:
+      method: get
+      resourcePath: /api/wsprj
+      description: workspace - projects mapping workspace 기준 모든 목록 조회
+    Createwpmapping:
+      method: post
+      resourcePath: /api/wsprj
+      description: workspace - projects mapping 생성
+    addProjectToWorkspace:
+      method: post
+      resourcePath: /api/workspaces/assign/projects
+      description: workspace에 project 등록
+    Getworkspaceuserrolemappinglistbyworkspaceid:
+      method: get
+      resourcePath: /api/wsuserrole/workspace/id/{workspaceId}
+      description: workspace - user - role mapping 목록 workspace 기준 조회
+    Signup:
+      method: post
+      resourcePath: /api/auth/signup
+      description: 신규 사용자 회원가입 (관리자 승인 후 로그인 가능)
+    Login:
+      method: post
+      resourcePath: /api/auth/login
+      description: ID/Password를 받아 JWT 세션 토큰을 반환
+    Gettokeninfo:
+      method: get
+      resourcePath: /api/auth/tokeninfo
+      description: 유저 정보 조회
+    Getcurrentpermissioncsv:
+      method: get
+      resourcePath: /api/permission/file/framework/{framework}
+      description: 현재 권한을 CSV 형태로 가져옵니다.
+    Importpermissionbycsv:
+      method: post
+      resourcePath: /api/permission/file/framework/{framework}
+      description: CSV 기반으로 권한을 업데이트 합니다.
+    Getprojectbyid:
+      method: get
+      resourcePath: /api/prj/project/id/{projectId}
+      description: project 단건 조회
+    Updateprojectbyid:
+      method: put
+      resourcePath: /api/prj/project/id/{projectId}
+      description: project 수정
+    Deleteprojectbyid:
+      method: delete
+      resourcePath: /api/prj/project/id/{projectId}
+      description: project 삭제
+    deleteWorkspace:
+      method: delete
+      resourcePath: /api/workspaces/id/{workspaceId}
+      description: workspace 삭제
+    getWorkspaceByID:
+      method: get
+      resourcePath: /api/workspaces/id/{workspaceId}
+      description: workspace 단건 조회
+    updateWorkspace:
+      method: put
+      resourcePath: /api/workspaces/id/{workspaceId}
+      description: workspace 수정
+    Getcerts:
+      method: get
+      resourcePath: /api/auth/certs
+      description: 유저 토큰의 사용가능 유무
+    Authgetuservalidate:
+      method: get
+      resourcePath: /api/auth/validate
+      description: 유저 토큰의 사용가능 유무
+    Getpermission:
+      method: get
+      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}
+      description: 권한을 검색합니다.
+    Updateresourcepermissionbyoperationid:
+      method: put
+      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}
+      description: 권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다.
+    Activeuser:
+      method: post
+      resourcePath: /api/user/active
+      description: 권한 있는 사용자가 해당 유저를 활성화합니다.
+    Getworkspaceuserrolemappinglistorderbyworkspace:
+      method: get
+      resourcePath: /api/wsuserrole
+      description: workspace - user - role mapping 목록 workspace 기준 전체 조회
+    Createworkspaceuserrolemappingbyname:
+      method: post
+      resourcePath: /api/wsuserrole
+      description: workspace - user - role mapping 생성
+    Getallavailablemenus:
+      method: post
+      resourcePath: /api/users/menus/list
+      description: 해당 프레임워크 사용자에게 할당된 메뉴 리스트를 반환합니다.
+    Getmappedmenusbyrolelist:
+      method: post
+      resourcePath: /api/menus/platform-roles/list
+      description: 해당 프레임워크 역할에 할당된 메뉴 리스트를 반환합니다.
+    Deleteuser:
+      method: delete
+      resourcePath: /api/users/id/{userId}
+      description: 사용자를 삭제합니다.
+    Updateuser:
+      method: put
+      resourcePath: /api/users/id/{userId}
+      description: 사용자 정보를 업데이트 합니다.
+    Createworkspace:
+      method: post
+      resourcePath: /api/workspaces
+      description: workspace 생성
+    listWorkspaces:
+      method: post
+      resourcePath: /api/workspaces/list
+      description: workspace 목록 조회
+    listMciamPermissions:
+      method: post
+      resourcePath: /api/permissions/mciam/list
+      description: 모든 권한을 가져옵니다.
+    listUsersAndRolesByWorkspaces:
+      method: post
+      resourcePath: /api/workspaces/id/{workspaceId}/users/list
+      description: workspace 목록 조회
+    getWorkspaceProjectsByWorkspaceId:
+      method: get
+      resourcePath: /api/workspaces/id/{workspaceId}/projects/list
+    ListUsersAndRolesByWorkspaces:
+      method: post
+      resourcePath: /api/workspaces/id/{workspaceId}/users/list
+    listWorkspaceProjects:
+      method: post
+      resourcePath: /api/workspaces/projects/list
+    getTempCredentialProviders:
+      method: get
+      resourcePath: /api/auth/temp-credential-csps
+      description: 임시 자격 증명을 지원하는 CSP 목록 조회
+    Appendresourcepermissionpolicesbyoperationid:
+      method: put
+      resourcePath: /api/permission/framewrok/{framework}/operationid/{operationid}/append
+      description: 권한을 OperationId를 기반으로 리소스 권한을 업데이트합니다.
+    Updateresource:
+      method: put
+      resourcePath: /api/resource/id/{id}
+      description: 리소스를 업데이트 합니다.
+    Deleteresource:
+      method: delete
+      resourcePath: /api/resource/id/{id}
+      description: 리소스를 삭제합니다.
+    Getmenuresources:
+      method: post
+      resourcePath: /api/menus/list
+      description: 메뉴 리소스를 검색합니다.
     Listmenustree:
       method: post
       resourcePath: /api/menus/menus-tree/list
-      description: "List all menus as tree structure (Admin only)"
+      description: List all menus as tree structure (Admin only)
     Createmenu:
       method: post
       resourcePath: /api/menus
-      description: "Create a new menu"
+      description: Create a new menu
     Getmenubyid:
       method: get
       resourcePath: /api/menus/id/{menuId}
-      description: "Get menu details by ID"
+      description: Get menu details by ID
     Updatemenu:
       method: put
       resourcePath: /api/menus/id/{menuId}
-      description: "Update menu details"
+      description: Update menu details
     Deletemenu:
       method: delete
       resourcePath: /api/menus/id/{menuId}
-      description: "Delete a menu"
+      description: Delete a menu
+    Getallpermissions:
+      method: get
+      resourcePath: /api/ticket
+      description: 사용자는 uma_protection Role 을 가져야 한다.
+    Getpermissionticket:
+      method: post
+      resourcePath: /api/ticket
+      description: 사용자는 uma_protection Role 을 가져야 한다.
+    getProjectsByWorkspaceId:
+      method: get
+      resourcePath: /api/workspaces/id/{workspaceId}/projects/list
+      description: workspace - projects mapping workspace 기준 목록 조회
+    listUserWorkspaces:
+      method: post
+      resourcePath: /api/users/workspaces/list
+      description: workspace - user - role mapping 목록 user 기준 조회
+    Deleteworkspaceuserrolemapping:
+      method: delete
+      resourcePath: /api/wsuserrole/workspace/id/{workspaceId}/user/id/{userId}
+      description: workspace - user - role mapping 목록 workspace 와 user 로 mapping 삭제
+    Loginrefresh:
+      method: post
+      resourcePath: /api/auth/refresh
+      description: refresh_token과 기존 JWT를 받아, 새로운 JWT 토큰 발급
+    Getuserinfo:
+      method: get
+      resourcePath: /api/auth/userinfo
+      description: 유저 정보 조회
+    Updateuseinfonotuse:
+      method: put
+      resourcePath: /api/auth/userinfo
+      description: 유저 정보 조회
+    Createapiresourcesbyapiyaml:
+      method: post
+      resourcePath: /api/resource/file/framework/{framework}
+      description: "mc-admin-cli 에서 생성한 api yaml을 바탕으로 모든 리소스를 등록합니다.  \n리소스가 중복될시 오류를 반환하고 업데이트 하지 않습니다."
+    Resetresource:
+      method: delete
+      resourcePath: /api/resource/reset
+      description: 모든 리소스를 삭제합니다.
+    Syncprojectlistwithmcinfra:
+      method: get
+      resourcePath: /api/tool/mcinfra/sync
+      description: "연결된 TB(mcinframanager)의 NS 리스트를 Project List 로 등록.  \n  \n기존 등록된 project 와 중복이 발생하면 오류 발생. 새로운 환경에서 첫 회 실행하는 것을 추천."
+    Getdependentpermissionsbypolicyid:
+      method: get
+      resourcePath: /api/permission/policyid/{policyid}
+      description: 권한을 검색합니다.
+    Searchprojectsbyname:
+      method: get
+      resourcePath: /api/prj/project/{projectName}
+      description: project 목록 검색
+    Resetmenuresource:
+      method: delete
+      resourcePath: /api/resource/reset/menu
+      description: 모든 메뉴 리소스를 삭제합니다.
+    Deleterolebyid:
+      method: delete
+      resourcePath: /api/roles/id/{roleId}
+      description: role 삭제
+    Getrolebyid:
+      method: get
+      resourcePath: /api/role/id/{roleId}
+      description: role 단건 조회
+    Updaterolebyid:
+      method: put
+      resourcePath: /api/role/id/{roleId}
+      description: role 수정
+    Getrolebypolicyidnotuse:
+      method: get
+      resourcePath: /api/role/policyid/{policyid}
+      description: role 단건 조회
+    Createmenuresourcesbymenuyaml:
+      method: post
+      resourcePath: /api/resource/file/framework/{framework}/menu
+      description: mc-web-console 등 menu yaml을 사용해서 메뉴 리소스를 등록합니다.
+    Listusers:
+      method: post
+      resourcepath: /api/users/list
+      description: 사용자 목록 조회
+    getUserByID:
+      method: get
+      resourcePath: /api/users/id/{userId}
+      description: 사용자 단건 조회 by id
+    Getuserbyname:
+      method: get
+      resourcePath: /api/users/name/{username}
+      description: 사용자 단건 조회 by name
+    Getuserworkspacesbyuserid:
+      method: get
+      resourcePath: /api/users/id/{userId}/workspaces/list
+      description: 특정 사용자의 워크스페이스 목록조회
+    Createuser:
+      method: post
+      resourcePath: /api/users
+      description: 유저를 등록합니다.
+    Deactiveuser:
+      method: post
+      resourcePath: /api/user/deactive
+      description: 권한 있는 사용자가 해당 유저를 비활성화합니다.
+    removeWorkspaceFromProject:
+      method: delete
+      resourcePath: /api/projects/unassign/workspaces
+      description: Workspace에서 Project 할당 해제
+    assignPlatformRole:
+      method: post
+      resourcePath: /api/roles/assign/platform-role
+      description: Platform Role 할당
+    removePlatformRole:
+      method: delete
+      resourcePath: /api/roles/unassign/platform-role
+      description: 사용자에게서 Platform Role 제거
     UpdateUserStatus:
       method: post
       resourcePath: /api/users/id/{userId}/status
-      description: "사용자 승인/비활성화 (enabled true/false)"
+      description: 사용자 승인/비활성화 (enabled true/false)
     ResetUserPassword:
       method: put
       resourcePath: /api/users/id/{userId}/password
-      description: "관리자가 사용자 비밀번호 재설정"
+      description: 관리자가 사용자 비밀번호 재설정
     ChangeMyPassword:
       method: put
       resourcePath: /api/users/me/password
-      description: "사용자 본인 비밀번호 변경"
+      description: 사용자 본인 비밀번호 변경
     Createorganization:
       method: post
       resourcePath: /api/organizations
-      description: "그룹 생성"
+      description: 그룹 생성
     Getorganizations:
       method: get
       resourcePath: /api/organizations
-      description: "그룹 목록/트리 조회 (query: tree=true면 중첩 구조)"
+      description: '그룹 목록/트리 조회 (query: tree=true면 중첩 구조)'
     Getorganizationbyid:
       method: get
       resourcePath: /api/organizations/id/{organizationId}
-      description: "그룹 단건 조회 by ID"
+      description: 그룹 단건 조회 by ID
     Getorganizationbycode:
       method: get
       resourcePath: /api/organizations/code/{code}
-      description: "그룹 단건 조회 by code"
+      description: 그룹 단건 조회 by code
     Updateorganization:
       method: put
       resourcePath: /api/organizations/id/{organizationId}
-      description: "그룹 수정 (부모 변경 시 하위 코드 자동 재생성)"
+      description: 그룹 수정 (부모 변경 시 하위 코드 자동 재생성)
     Deleteorganization:
       method: delete
       resourcePath: /api/organizations/id/{organizationId}
-      description: "그룹 삭제 (하위 그룹·소속 사용자 있으면 400)"
+      description: 그룹 삭제 (하위 그룹·소속 사용자 있으면 400)
     Getorganizationusers:
       method: get
       resourcePath: /api/organizations/id/{organizationId}/users
-      description: "그룹 소속 사용자 목록"
+      description: 그룹 소속 사용자 목록
     Assignuserorganizations:
       method: post
       resourcePath: /api/users/id/{userId}/organizations
-      description: "사용자 그룹 할당 (다중)"
-    assignGroupUsers:
-      method: post
-      resourcePath: /api/groups/id/{groupId}/users
-      description: "그룹에 사용자 일괄 할당 (group 입장)"
+      description: 사용자 그룹 할당 (다중)
     Getuserorganizations:
       method: get
       resourcePath: /api/users/id/{userId}/organizations
-      description: "사용자 소속 그룹 목록"
+      description: 사용자 소속 그룹 목록
     Removeuserorganization:
       method: delete
       resourcePath: /api/users/id/{userId}/organizations/{organizationId}
-      description: "사용자 그룹 제거"
+      description: 사용자 그룹 제거
+    assignGroupPlatformRole:
+      method: post
+      resourcePath: /api/groups/id/{groupId}/platform-roles
+      description: 그룹에 Platform Role 할당
+    getGroupPlatformRoles:
+      method: get
+      resourcePath: /api/groups/id/{groupId}/platform-roles
+      description: 그룹의 Platform Role 목록 조회
     listCspAccounts:
       method: post
       resourcePath: /api/csp-accounts/list
-      description: "CSP 계정 목록 조회 (필터: csp_type)"
+      description: 'CSP 계정 목록 조회 (필터: csp_type)'
     createCspAccount:
       method: post
       resourcePath: /api/csp-accounts
-      description: "CSP 계정 등록"
+      description: CSP 계정 등록
     getCspAccountByID:
       method: get
       resourcePath: /api/csp-accounts/id/{accountId}
-      description: "CSP 계정 단건 조회 by ID"
+      description: CSP 계정 단건 조회 by ID
     updateCspAccount:
       method: put
       resourcePath: /api/csp-accounts/id/{accountId}
-      description: "CSP 계정 수정"
+      description: CSP 계정 수정
     deleteCspAccount:
       method: delete
       resourcePath: /api/csp-accounts/id/{accountId}
-      description: "CSP 계정 삭제"
+      description: CSP 계정 삭제
     validateCspAccount:
       method: post
       resourcePath: /api/csp-accounts/id/{accountId}/validate
-      description: "CSP 계정 자격증명 유효성 검증"
+      description: CSP 계정 자격증명 유효성 검증
     activateCspAccount:
       method: post
       resourcePath: /api/csp-accounts/id/{accountId}/activate
-      description: "CSP 계정 활성화"
+      description: CSP 계정 활성화
     deactivateCspAccount:
       method: post
       resourcePath: /api/csp-accounts/id/{accountId}/deactivate
-      description: "CSP 계정 비활성화"
+      description: CSP 계정 비활성화
     GetProjectSyncDiff:
       method: get
       resourcePath: /api/setup/projects/sync-diff
@@ -1194,745 +1183,3286 @@ serviceActions:
     listMenus:
       method: post
       resourcePath: /api/menus/list
-      description: "메뉴 목록 조회 (전체)"
+      description: "메뉴 목록 조회 (전체). FR-CLOUD-ADMIN-006-08 Setup Status — 메뉴 등록 건수 산출."
     InitialMenus:
       method: post
       resourcePath: /api/setup/initial-menus
-      description: "menu.yaml 기반 메뉴 일괄 재등록 (1_setup_auto.sh init_menu와 동일)"
+      description: "menu.yaml 기반 메뉴 일괄 재등록 (1_setup_auto.sh init_menu와 동일). FR-006-08 Re-sync."
     SyncMcmpApis:
       method: post
       resourcePath: /api/setup/sync-mcmp-apis
-      description: "api.yaml 기반 mcmpApi 카탈로그 재동기화 (1_setup_auto.sh init_api_resources와 동일)"
+      description: "api.yaml 기반 mcmpApi 카탈로그 재동기화 (1_setup_auto.sh init_api_resources와 동일). FR-006-08 Re-sync."
     syncProjects:
       method: post
       resourcePath: /api/setup/sync-projects
-      description: "mc-infra-manager의 namespace 목록을 가져와 project 테이블과 동기화"
-
+      description: "mc-infra-manager의 namespace 목록을 가져와 project 테이블과 동기화 (1_setup_auto.sh sync_projects와 동일). FR-006-08 Re-sync."
   mc-infra-manager:
+    GetInfraReadyzInit:
+      method: put
+      resourcePath: /readyz/init
+      description: "mc-infra-manager 초기화. credential valid 선행 필요. image/spec 등 초기 데이터 로드."
     Lookupspeclist:
       method: post
       resourcePath: /lookupSpecs
       description: "Lookup spec list"
-    Getlatencybenchmark:
-      method: get
-      resourcePath: /ns/{nsId}/benchmarkLatency/mci/{mciId}
-      description: "Run MCI benchmark for network latency"
-    Getallsecuritygroup:
-      method: get
-      resourcePath: /ns/{nsId}/resources/securityGroup
-      description: "List all Security Groups or Security Groups' ID"
-    Postsecuritygroup:
+    AddNLBVMs:
       method: post
-      resourcePath: /ns/{nsId}/resources/securityGroup
-      description: "Create Security Group"
-    Delallsecuritygroup:
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}/node
+      description: Add VMs to NLB
+    AnalyzeProvisioningRisk:
+      method: get
+      resourcePath: /provisioning/risk/{specId}
+      description: 'Evaluate the likelihood of provisioning failure based on historical data for a specific VM specification and image combination.
+
+        This endpoint provides intelligent risk assessment to help prevent deployment failures:
+
+
+        **Risk Analysis Factors:**
+
+        - Historical failure rate for the VM specification
+
+        - Image-specific compatibility with the spec
+
+        - Recent failure patterns and trends
+
+        - Cross-reference of spec+image combination success rates
+
+
+        **Risk Levels:**
+
+        - `high`: Very likely to fail (>80% failure rate or image-specific failures)
+
+        - `medium`: Moderate risk (50-80% failure rate or mixed results)
+
+        - `low`: Low risk (<50% failure rate or no previous failures)
+
+        - `unknown`: Insufficient data for analysis
+
+
+        **Recommended Actions by Risk Level:**
+
+        - **High Risk**: Consider alternative specs or images, verify CSP quotas and permissions
+
+        - **Medium Risk**: Proceed with caution, have backup plans ready
+
+        - **Low Risk**: Safe to proceed with normal deployment
+
+
+        **Integration Points:**
+
+        - Automatically called during MCI review process
+
+        - Can be used in CI/CD pipelines for deployment validation
+
+        - Helpful for capacity planning and resource selection'
+    AnalyzeProvisioningRiskDetailed:
+      method: get
+      resourcePath: /provisioning/risk/detailed
+      description: 'Provides comprehensive risk analysis with separate assessments for VM specification and image risks, plus actionable recommendations.
+
+        This endpoint offers enhanced risk analysis by separating spec-level and image-level risk factors:
+
+
+        **Risk Analysis Breakdown:**
+
+        - **Spec Risk**: Analyzes whether the VM specification itself has compatibility or resource issues
+
+        - **Image Risk**: Evaluates the track record of the specific image with this spec
+
+        - **Overall Risk**: Combines both factors to determine the primary risk source
+
+        - **Recommendations**: Provides actionable guidance based on risk analysis
+
+
+        **Spec Risk Factors:**
+
+        - Number of different images that failed with this spec (indicates spec-level issues)
+
+        - Overall failure rate across all images
+
+        - Success/failure ratio with various images
+
+
+        **Image Risk Factors:**
+
+        - Previous success/failure history of this specific image with this spec
+
+        - Whether this is a new, untested combination
+
+
+        **Recommendation Types:**
+
+        - Change VM specification (when spec is the primary risk factor)
+
+        - Try different image (when image is the primary risk factor)
+
+        - Monitor deployment closely (for new combinations or medium risk)
+
+        - Proceed with confidence (for low-risk combinations)'
+    BulkDeleteGlobalDnsRecord:
       method: delete
-      resourcePath: /ns/{nsId}/resources/securityGroup
-      description: "Delete all Security Groups"
-    Postconfig:
+      resourcePath: /resources/globalDns/records
+      description: 'Delete multiple DNS records from Route53 in a single request.
+
+        Records are grouped by domain and submitted as a single ChangeBatch per domain for efficiency.'
+    CancelExecutionTask:
       method: post
-      resourcePath: /config
-      description: "Create or Update config (TB_SPIDER_REST_URL, TB_DRAGONFLY_REST_URL, ...)"
-    Initallconfig:
-      method: delete
-      resourcePath: /config
-      description: "Init all configs"
-    Getallconfig:
-      method: get
-      resourcePath: /config
-      description: "List all configs"
-    Inspectresources:
-      method: post
-      resourcePath: /inspectResources
-      description: "Inspect Resources (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug, CB-Spider, CSP"
-    Postk8sclusterdynamiccheckrequest:
-      method: post
-      resourcePath: /k8sClusterDynamicCheckRequest
-      description: "Check available ConnectionConfig list before create K8sCluster Dynamically from common spec and image"
-    Deldatadisk:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
-      description: "Delete Data Disk"
-    Getdatadisk:
-      method: get
-      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
-      description: "Get Data Disk"
-    Putdatadisk:
-      method: put
-      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
-      description: "Upsize Data Disk"
-    Putsshkey:
-      method: put
-      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: "Update SSH Key"
-    Delsshkey:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: "Delete SSH Key"
-    Getsshkey:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
-      description: "Get SSH Key"
-    Getns:
-      method: get
-      resourcePath: /ns/{nsId}
-      description: "Get namespace"
-    Putns:
-      method: put
-      resourcePath: /ns/{nsId}
-      description: "Update namespace"
-    Delns:
-      method: delete
-      resourcePath: /ns/{nsId}
-      description: "Delete namespace"
-    Checkresource:
-      method: get
-      resourcePath: /ns/{nsId}/checkResource/{resourceType}/{resourceId}
-      description: "Check resources' existence"
-    Getallnlb:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb
-      description: "List all NLBs or NLBs' ID"
-    Postnlb:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb
-      description: "Create NLB"
-    Delallnlb:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb
-      description: "Delete all NLBs"
-    Registercspnativeresources:
-      method: post
-      resourcePath: /registerCspResources
-      description: "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to CB-Tumblebug"
-    Getcontrolmci:
-      method: get
-      resourcePath: /ns/{nsId}/control/mci/{mciId}
-      description: "Control the lifecycle of MCI (refine, suspend, resume, reboot, terminate)"
-    Getmonitordata:
-      method: get
-      resourcePath: /ns/{nsId}/monitoring/mci/{mciId}/metric/{metric}
-      description: "Get monitoring data of specified MCI for specified monitoring metric (cpu, memory, disk, network)"
-    Postobjectstorage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/objectStorage
-      description: "Create a Object Storages\n\nSupported CSPs: AWS, Azure\n- Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral\n\n- Note - Please check the `requiredCSPResource` property which includes CSP specific values.\n\n- Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/117\n"
-    Getallobjectstorage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/objectStorage
-      description: "Get all Object Storages (TBD)"
-    Postutiltovalidatenetwork:
-      method: post
-      resourcePath: /util/net/validate
-      description: "Validate a hierarchical configuration of a VPC network or multi-cloud network consisting of multiple VPC networks"
-    Getavailablek8snodeimage:
-      method: get
-      resourcePath: /availableK8sNodeImage
-      description: "(UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image"
-    Getk8sclusterinfo:
-      method: get
-      resourcePath: /k8sClusterInfo
-      description: "Get kubernetes cluster information"
-    Loadassets:
-      method: get
-      resourcePath: /loadAssets
-      description: "Load Common Resources from internal asset files (Spec, Image)"
-    Getcontrolmcivm:
-      method: get
-      resourcePath: /ns/{nsId}/control/mci/{mciId}/vm/{vmId}
-      description: "Control the lifecycle of VM (suspend, resume, reboot, terminate)"
-    Delallvnet:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/vNet
-      description: "Delete all VNets"
-    Getallvnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet
-      description: "List all VNets or VNets' ID"
-    Postvnet:
-      method: post
-      resourcePath: /ns/{nsId}/resources/vNet
-      description: "Create a new VNet"
-    Postmcivmsnapshot:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/snapshot
-      description: "Snapshot VM and create a Custom Image Object using the Snapshot"
-    Getregion:
-      method: get
-      resourcePath: /provider/{providerName}/region/{regionName}
-      description: "Get registered region info"
-    Postmcidynamiccheckrequest:
-      method: post
-      resourcePath: /mciDynamicCheckRequest
-      description: "Check available ConnectionConfig list before create MCI Dynamically from common spec and image"
-    Postfiletomci:
-      method: post
-      resourcePath: /ns/{nsId}/transferFile/mci/{mciId}
-      description: "Transfer a file to specified MCI to the specified path.\nThe file size should be less than 10MB.\nNot for gerneral file transfer but for specific purpose (small configuration files)."
-    Getbenchmark:
-      method: post
-      resourcePath: /ns/{nsId}/benchmark/mci/{mciId}
-      description: "Run MCI benchmark for a single performance metric and return results"
-    Getnlb:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}
-      description: "Get NLB"
-    Delnlb:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}
-      description: "Delete NLB"
-    Postregistersubnet:
-      method: post
-      resourcePath: /ns/{nsId}/registerCspResource/vNet/{vNetId}/subnet
-      description: "Register Subnet, which was created in CSP"
-    Fetchimages:
-      method: post
-      resourcePath: /ns/{nsId}/resources/fetchImages
-      description: "Fetch images"
-    Getobjectstorage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/objectStorage/{objectStorageId}
-      description: "Get resource info of a Object Storage"
-    Deleteobjectstorage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/objectStorage/{objectStorageId}
-      description: "Delete a Object Storage"
-    Removelabel:
-      method: delete
-      resourcePath: /label/{labelType}/{uid}/{key}
-      description: "Remove a label from a resource identified by its uid"
-    Getbastionnodes:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion
-      description: "Get bastion nodes for a VM"
-    Getspec:
-      method: get
-      resourcePath: /ns/{nsId}/resources/spec/{specId}
-      description: "Get spec"
-    Putspec:
-      method: put
-      resourcePath: /ns/{nsId}/resources/spec/{specId}
-      description: "Update spec"
-    Delspec:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/spec/{specId}
-      description: "Delete spec"
-    Getsqldb:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
-      description: "Get resource info of a SQL datatbase"
-    Deletesqldb:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
-      description: "Delete a SQL datatbase"
-    Getvnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
-      description: "Get VNet"
-    Delvnet:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
-      description: "Delete VNet\n- withsubnets: delete VNet and its subnets\n- refine: delete information of VNet and its subnets if there's no info/resource in Spider/CSP\n- force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP"
-    Testjwtauth:
-      method: get
-      resourcePath: /auth/test
-      description: "Test JWT authentication"
-    Getpublickeyforcredentialencryption:
-      method: get
-      resourcePath: /credential/publicKey
-      description: "Generates an RSA key pair using a 4096-bit key size with the RSA algorithm. The public key is generated using the RSA algorithm with OAEP padding and SHA-256 as the hash function. This key is used to encrypt an AES key that will be used for hybrid encryption of credentials."
-    Recommendk8snode:
-      method: post
-      resourcePath: /k8sClusterRecommendNode
-      description: "Recommend K8sCluster's Node plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
-    Postmcivm:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm
-      description: "Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize for multiple VMs)"
-    Postspec:
-      method: post
-      resourcePath: /ns/{nsId}/resources/spec
-      description: "Register spec"
-    Delallsharedresources:
-      method: delete
-      resourcePath: /ns/{nsId}/sharedResources
-      description: "Delete all Default Resource Objects in the given namespace"
-    Getrequiredk8ssubnetcount:
-      method: get
-      resourcePath: /requiredK8sSubnetCount
-      description: "Get the required subnet count to create a K8sCluster"
-    Checkk8snodegroupsonk8screation:
-      method: get
-      resourcePath: /checkK8sNodeGroupsOnK8sCreation
-      description: "Check whether nodegroups are required during the K8sCluster creation"
-    Getmcigroupids:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/subgroup
-      description: "List SubGroup IDs in a specified MCI"
-    Putvmdatadisk:
-      method: put
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk
-      description: "Attach/Detach available dataDisk"
-    Postvmdatadisk:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk
-      description: "Provisioning (Create and attach) dataDisk"
-    Getvmdatadisk:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk
-      description: "Get available dataDisks for a VM"
-    Getsitetositevpn:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}
-      description: "Get resource info of a site-to-site VPN (Currently, GCP-AWS is supported)"
-    Putsitetositevpn:
-      method: put
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}
-      description: "(To be provided) Update a site-to-site VPN"
-    Deletesitetositevpn:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}
-      description: "Delete a site-to-site VPN (Currently, GCP-AWS is supported)"
-    Getcustomimage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
-      description: "Get customImage"
-    Delcustomimage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
-      description: "Delete customImage"
-    Getallrequests:
-      method: get
-      resourcePath: /requests
-      description: "Get details of all requests with optional filters."
-    Deleteallrequests:
-      method: delete
-      resourcePath: /requests
-      description: "Delete details of all requests"
-    Getcloudinfo:
-      method: get
-      resourcePath: /cloudInfo
-      description: "Get cloud information"
-    Getconnconfiglist:
-      method: get
-      resourcePath: /connConfig
-      description: "List all registered ConnConfig"
-    Deletederegistervnet:
-      method: delete
-      resourcePath: /ns/{nsId}/deregisterCspResource/vNet/{vNetId}
-      description: "Deregister the VNet, which was created in CSP"
-    Putsetk8snodegroupautoscaling:
-      method: put
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoscaling
-      description: "Set a K8sNodeGroup's Autoscaling On/Off"
-    Getallcustomimage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/customImage
-      description: "List all customImages or customImages' ID"
-    Postcustomimage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/customImage
-      description: "Register existing Custom Image in a CSP (option=register)"
-    Delallcustomimage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/customImage
-      description: "Delete all customImages"
-    Filterspecsbyrange:
-      method: post
-      resourcePath: /ns/{nsId}/resources/filterSpecsByRange
-      description: "Filter specs by range"
-    Postsystemmci:
-      method: post
-      resourcePath: /systemMci
-      description: "Create System MCI Dynamically for Special Purpose"
-    Lookupspec:
-      method: post
-      resourcePath: /lookupSpec
-      description: "Lookup spec"
-    Postk8snodegroup:
-      method: post
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup
-      description: "Add a K8sNodeGroup"
-    Getnlbhealth:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/healthz
-      description: "Get NLB Health"
-    Postmcisubgroupscaleout:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId}
-      description: "ScaleOut subGroup in specified MCI"
-    Getmcigroupvms:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId}
-      description: "List VMs with a SubGroup label in a specified MCI"
-    Deletederegistersubnet:
-      method: delete
-      resourcePath: /ns/{nsId}/deregisterCspResource/vNet/{vNetId}/subnet/{subnetId}
-      description: "Deregister Subnet, which was created in CSP"
-    Putchangek8snodegroupautoscalesize:
-      method: put
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize
-      description: "Change a K8sNodeGroup's Autoscale Size"
-    Getallmcipolicy:
-      method: get
-      resourcePath: /ns/{nsId}/policy/mci
-      description: "List all MCI policies"
-    Delallmcipolicy:
-      method: delete
-      resourcePath: /ns/{nsId}/policy/mci
-      description: "Delete all MCI policies"
-    Postimage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/image
-      description: "Register image"
-    Delallimage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/image
-      description: "Delete all images"
-    Getallimage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/image
-      description: "List all images or images' ID"
-    Postsubnet:
-      method: post
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
-      description: "Create Subnet"
-    Getallsubnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
-      description: "List all subnets"
-    Putupgradek8scluster:
-      method: put
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/upgrade
-      description: "Upgrade a K8sCluster's version"
-    Getmcivm:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}
-      description: "Get VM in specified MCI"
-    Delmcivm:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{vmId}
-      description: "Delete VM in specified MCI"
-    Postinstallmonitoragenttomci:
-      method: post
-      resourcePath: /ns/{nsId}/monitoring/install/mci/{mciId}
-      description: "Install monitoring agent (CB-Dragonfly agent) to MCI"
-    Getobject:
-      method: get
-      resourcePath: /object
-      description: "Get value of an object"
-    Deleteobject:
-      method: delete
-      resourcePath: /object
-      description: "Delete an object"
-    Getavailablek8sclusterversion:
-      method: get
-      resourcePath: /availableK8sVersion
-      description: "Get available kubernetes cluster version"
-    Lookupimage:
-      method: post
-      resourcePath: /lookupImage
-      description: "Lookup image"
-    Postregistervnet:
-      method: post
-      resourcePath: /ns/{nsId}/registerCspResource/vNet
-      description: "Register the VNet, which was created in CSP"
-    Getallsshkey:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sshKey
-      description: "List all SSH Keys or SSH Keys' ID"
-    Postsshkey:
-      method: post
-      resourcePath: /ns/{nsId}/resources/sshKey
-      description: "Create SSH Key"
-    Delallsshkey:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sshKey
-      description: "Delete all SSH Keys"
-    Getproviderlist:
-      method: get
-      resourcePath: /provider
-      description: "List all registered Providers"
-    Checkk8snodeimagedesignation:
-      method: get
-      resourcePath: /checkK8sNodeImageDesignation
-      description: "Check whether node image designation is possible to create a K8sCluster"
-    Getconfig:
-      method: get
-      resourcePath: /config/{configId}
-      description: "Get config"
-    Initconfig:
-      method: delete
-      resourcePath: /config/{configId}
-      description: "Init config"
-    Registercredential:
-      method: post
-      resourcePath: /credential
-      description: "This API registers credential information using hybrid encryption. The process involves compressing and encrypting sensitive data with AES-256, encrypting the AES key with a 4096-bit RSA public key (retrieved via `GET /credential/publicKey`), and using OAEP padding with SHA-256. All values, including the AES key, must be base64 encoded before sending, and the public key token ID must be included in the request."
-    Getcontrolk8scluster:
-      method: get
-      resourcePath: /ns/{nsId}/control/k8sCluster/{k8sClusterId}
-      description: "Control the creation of K8sCluster (continue, withdraw)"
-    Postmcivmdynamic:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vmDynamic
-      description: "Create VM Dynamically and add it to MCI"
-    Postutiltodesignnetwork:
-      method: post
-      resourcePath: /util/net/design
-      description: "Design a hierarchical network configuration of a VPC network or multi-cloud network consisting of multiple VPC networks"
-    Retrieveregionlistfromcsp:
-      method: get
-      resourcePath: /regionFromCsp
-      description: "RetrieveR all region lists from CSPs"
-    Postteststreamresponse:
-      method: post
-      resourcePath: /testStreamResponse
-      description: "Receives a number and streams the decrementing number every second until zero"
-    Removebastionnodes:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/bastion/{bastionVmId}
-      description: "Remove a bastion VM from all vNets"
-    Addnlbvms:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm
-      description: "Add VMs to NLB"
-    Removenlbvms:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm
-      description: "Delete VMs from NLB"
-    Getallsitetositevpn:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn
-      description: "Get all site-to-site VPNs"
-    Postsitetositevpn:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn
-      description: "Create a site-to-site VPN\n\nThe supported CSP sets are as follows:\n\n- GCP and AWS (Note: It will take about `15 minutes`.)\n\n- GCP and Azure (Note: It will take about `30 minutes`.)"
-    Delfirewallrules:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
-      description: "Delete FirewallRules"
-    Postfirewallrules:
-      method: post
-      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
-      description: "Create FirewallRules"
-    Getobjects:
-      method: get
-      resourcePath: /objects
-      description: "List all objects for a given key"
-    Deleteobjects:
-      method: delete
-      resourcePath: /objects
-      description: "Delete child objects along with the given object"
-    Getallbenchmark:
-      method: post
-      resourcePath: /ns/{nsId}/benchmarkAll/mci/{mciId}
-      description: "Run MCI benchmark for all performance metrics and return results"
-    Postmci:
-      method: post
-      resourcePath: /ns/{nsId}/mci
-      description: "Create MCI"
-    Delallmci:
-      method: delete
-      resourcePath: /ns/{nsId}/mci
-      description: "Delete all MCIs"
-    GetAllMci:
-      method: get
-      resourcePath: /ns/{nsId}/mci
-      description: "List all MCIs or MCIs' ID"
-    Postregistercspnativevm:
-      method: post
-      resourcePath: /ns/{nsId}/registerCspVm
-      description: "Register existing VM in a CSP to Cloud-Barista MCI"
-    Getallsqldb:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sqlDb
-      description: "Get all SQL Databases (TBD)"
-    Postsqldb:
-      method: post
-      resourcePath: /ns/{nsId}/resources/sqlDb
-      description: "Create a SQL Databases\n\nSupported CSPs: AWS, Azure, GCP, NCP\n- Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral, gcp-asia-northeast3, ncpvpc-kr\n\n- Note - Please check the `requiredCSPResource` property which includes CSP specific values.\n\n- Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/110\n"
-    Postk8sclusterdynamic:
-      method: post
-      resourcePath: /ns/{nsId}/k8sClusterDynamic
-      description: "Create K8sCluster Dynamically from common spec and image"
-    Putmonitoragentstatusinstalled:
-      method: put
-      resourcePath: /ns/{nsId}/monitoring/status/mci/{mciId}/vm/{vmId}
-      description: "Set monitoring agent (CB-Dragonfly agent) installation status installed (for Windows VM only)"
-    Postinstallbenchmarkagenttomci:
-      method: post
-      resourcePath: /ns/{nsId}/installBenchmarkAgent/mci/{mciId}
-      description: "Install the benchmark agent to specified MCI"
-    Getk8scluster:
-      method: get
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
-      description: "Get K8sCluster"
-    Deletek8scluster:
-      method: delete
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
-      description: "Delete K8sCluster"
-    Getimage:
-      method: get
-      resourcePath: /ns/{nsId}/resources/image/{imageId}
-      description: "GetImage returns an image object if there are matched images for the given namespace and imageKey(Id, CspResourceName, GuestOS,...)"
-    Putimage:
-      method: put
-      resourcePath: /ns/{nsId}/resources/image/{imageId}
-      description: "Update image"
-    Delimage:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/image/{imageId}
-      description: "Delete image"
-    Getsubnet:
-      method: get
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
-      description: "Get Subnet"
-    Delsubnet:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
-      description: "Delete Subnet\n- refine: delete a subnet `object` if there's no resource on CSP or no inforamation on Spider\n- force: force: delete a subnet `resource` on a CSP regardless of the current resource status (e.g., attempt to delete even if in use)"
-    Getregions:
-      method: get
-      resourcePath: /provider/{providerName}/region
-      description: "Get registered region info"
-    Postcmdmci:
-      method: post
-      resourcePath: /ns/{nsId}/cmd/mci/{mciId}
-      description: "Send a command to specified MCI"
-    Fetchspecs:
-      method: post
-      resourcePath: /ns/{nsId}/resources/fetchSpecs
-      description: "Fetch specs"
-    Searchimage:
-      method: post
-      resourcePath: /ns/{nsId}/resources/searchImage
-      description: "Search image"
-    Getresourcesbylabelselector:
-      method: get
-      resourcePath: /resources/{labelType}
-      description: "Get resources based on a label selector. The label selector supports the following operators:\n- `=` : Selects resources where the label key equals the specified value (e.g., `env=production`).\n- `!=` : Selects resources where the label key does not equal the specified value (e.g., `tier!=frontend`).\n- `in` : Selects resources where the label key is in the specified set of values (e.g., `region in (us-west, us-east)`).\n- `notin` : Selects resources where the label key is not in the specified set of values (e.g., `env notin (production, staging)`).\n- `exists` : Selects resources where the label key exists (e.g., `env exists`).\n- `!exists` : Selects resources where the label key does not exist (e.g., `env !exists`)."
-    Getlabels:
-      method: get
-      resourcePath: /label/{labelType}/{uid}
-      description: "Get labels for a resource identified by its uid"
-    Createorupdatelabel:
-      method: put
-      resourcePath: /label/{labelType}/{uid}
-      description: "Create or update a label for a resource identified by its uid"
-    Lookupimagelist:
-      method: post
-      resourcePath: /lookupImages
-      description: "Lookup image list"
-    Recommendvm:
-      method: post
-      resourcePath: /mciRecommendVm
-      description: "Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
-    Getallns:
-      method: get
-      resourcePath: /ns
-      description: "List all namespaces or namespaces' ID"
-    Postns:
-      method: post
-      resourcePath: /ns
-      description: "Create namespace"
-    Delallns:
-      method: delete
-      resourcePath: /ns
-      description: "Delete all namespaces"
-    Forwardanyreqtoany:
-      method: post
-      resourcePath: /forward/{path}
-      description: "Forward any (GET) request to CB-Spider"
-    Checkhttpversion:
+      resourcePath: /ns/{nsId}/cmd/infra/{mciId}/task/{taskId}/cancel
+      description: Cancel a running execution task by task ID. This will send a cancellation signal to the task and update the VM command status.
+    CheckHTTPVersion:
       method: get
       resourcePath: /httpVersion
-      description: "Checks and logs the HTTP version of the incoming request to the server console."
-    Postk8scluster:
+      description: Checks and logs the HTTP version of the incoming request to the server console.
+    CheckK8sNodeGroupsOnK8sCreation:
+      method: get
+      resourcePath: /checkK8sNodeGroupsOnK8sCreation
+      description: Check whether nodegroups are required during the K8sCluster creation
+    CheckK8sNodeImageDesignation:
+      method: get
+      resourcePath: /checkK8sNodeImageDesignation
+      description: Check whether node image designation is possible to create a K8sCluster
+    CheckObjectStorage:
+      method: head
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+      description: Check existence of an object storage (bucket)
+    CheckResource:
+      method: get
+      resourcePath: /ns/{nsId}/checkResource/{resourceType}/{resourceId}
+      description: Check resources' existence
+    ClearAllVmCommandStatus:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatusAll
+      description: Delete all command status records for a VM
+    ComplementSshKeyRemoteCommand:
+      method: put
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}/complement
+      description: Update username and privateKey to enable remote command execution on registered VMs
+    CreateObjectStorage:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage
+      description: Create an object storage (bucket)
+    CreateObjectStorageLagacy:
+      method: put
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: '(To be deprecated) Create an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The `objectStorageName` must be globally unique across all existing buckets in the S3 compatible storage.
+
+        - The bucket namespace is shared by all users of the system.'
+    CreateOrUpdateLabel:
+      method: put
+      resourcePath: /label/{labelType}/{uid}
+      description: Create or update a label for a resource identified by its uid
+    CreateSharedResource:
       method: post
-      resourcePath: /ns/{nsId}/k8sCluster
-      description: "Create K8sCluster<br>Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1614"
-    Deleteallk8scluster:
+      resourcePath: /ns/{nsId}/sharedResource
+      description: Create shared resources for MC-Infra
+    DelAllCustomImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/customImage
+      description: Delete all customImages
+    DelAllDataDisk:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/dataDisk
+      description: Delete all Data Disks
+    DelAllImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/image
+      description: Delete all images
+    DelAllInfra:
+
+      method: delete
+      resourcePath: /ns/{nsId}/infra
+      description: Delete all MCIs
+    DelAllInfraPolicy:
+
+      method: delete
+      resourcePath: /ns/{nsId}/policy/infra
+      description: Delete all MCI policies
+    DelAllNLB:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb
+      description: Delete all NLBs
+    DelAllNs:
+      method: delete
+      resourcePath: /ns
+      description: Delete all namespaces
+    DelAllSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: Delete all Security Groups
+    DelAllSharedResources:
+      method: delete
+      resourcePath: /ns/{nsId}/sharedResources
+      description: Delete all Default Resource Objects in the given namespace
+    DelAllSshKey:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: Delete all SSH Keys
+    DelAllVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: Delete all VNets
+    DelCustomImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
+      description: Delete customImage
+    DelDataDisk:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+      description: Delete Data Disk
+    DelFirewallRules:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
+      description: 'Delete specific FirewallRules: Remove specified rules from the Security Group while keeping other existing rules.
+
+        This API will remove only the specified rules from the Security Group, leaving all other rules intact.
+
+
+        Usage:
+
+        Use this API to remove specific firewall rules from a Security Group. Only the rules matching the provided criteria will be deleted.
+
+        - Rules that exactly match the provided Direction, Protocol, Port, and CIDR will be removed.
+
+        - All other existing rules will remain unchanged.
+
+
+        Notes:
+
+        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+
+        - "Protocol" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).
+
+        - "Direction" must be either "inbound" or "outbound".
+
+        - "CIDR" is the allowed IP range.'
+    DelImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: Delete image
+    DelInfra:
+
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}
+      description: Delete MCI
+    DelInfraPolicy:
+
+      method: delete
+      resourcePath: /ns/{nsId}/policy/infra/{mciId}
+      description: Delete MCI Policy
+    DelInfraNode:
+
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}
+      description: Delete VM in specified MCI
+    DelNLB:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}
+      description: Delete NLB
+    DelNs:
+      method: delete
+      resourcePath: /ns/{nsId}
+      description: Delete namespace
+    DelSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: Delete Security Group
+    DelSpec:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: Delete spec
+    DelSshKey:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: Delete SSH Key
+    DelSubnet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
+      description: 'Delete Subnet
+
+        - refine: delete a subnet `object` if there''s no resource on CSP or no inforamation on Spider
+
+        - force: force: delete a subnet `resource` on a CSP regardless of the current resource status (e.g., attempt to delete even if in use)'
+    DelVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+      description: 'Delete VNet
+
+        - withsubnets: delete VNet and its subnets
+
+        - refine: delete information of VNet and its subnets if there''s no info/resource in Spider/CSP
+
+        - force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP'
+    DeleteAllK8sCluster:
       method: delete
       resourcePath: /ns/{nsId}/k8sCluster
-      description: "Delete all K8sClusters"
-    Getallk8scluster:
-      method: get
-      resourcePath: /ns/{nsId}/k8sCluster
-      description: "List all K8sClusters or K8sClusters' ID"
-    Postk8snodegroupdynamic:
+      description: Delete all K8sClusters
+    DeleteAllInfraDynamicTemplate:
+
+      method: delete
+      resourcePath: /ns/{nsId}/template/infra
+      description: Delete all MCI Dynamic Templates in a namespace.
+    DeleteAllRequests:
+      method: delete
+      resourcePath: /requests
+      description: Delete details of all requests
+    DeleteAllSecurityGroupTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/securityGroup
+      description: Delete all SecurityGroup Templates in a namespace.
+    DeleteAllVNetTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/vNet
+      description: Delete all vNet Templates in a namespace.
+    DeleteDataObject:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
+      description: Delete an object from an object storage (bucket)
+    DeleteDataObjectLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
+      description: (To be deprecated) Delete an object from a bucket
+    DeleteDeregisterSubnet:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/vNet/{vNetId}/subnet/{subnetId}
+      description: Deregister Subnet, which was created in CSP
+    DeleteDeregisterVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/vNet/{vNetId}
+      description: Deregister the VNet, which was created in CSP
+    DeleteGlobalDnsRecord:
+      method: delete
+      resourcePath: /resources/globalDns/record
+      description: 'Delete DNS record(s) from Route53. If setIdentifier is provided, deletes only that specific record.
+
+        If setIdentifier is empty, deletes all records matching the name and type.'
+    DeleteK8sCluster:
+      method: delete
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
+      description: Delete K8sCluster
+    DeleteK8sNodeGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}
+      description: Remove a K8sNodeGroup
+    DeleteInfraDynamicTemplate:
+
+      method: delete
+      resourcePath: /ns/{nsId}/template/infra/{templateId}
+      description: Delete a specific MCI Dynamic Template.
+    DeleteMultipleDataObjectsLagacy:
       method: post
-      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroupDynamic
-      description: "Create K8sNodeGroup Dynamically from common spec and image"
-    Getrequest:
-      method: get
-      resourcePath: /request/{reqId}
-      description: "Get details of a specific request"
-    Deleterequest:
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: '(To be deprecated) `Delete` multiple objects from a bucket
+
+
+        **Important Notes:**
+
+        - The request body must contain the list of objects to delete in XML format
+
+        - The `delete` query parameter must be set to `true`
+
+
+        **Request Body Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Object>
+
+        <Key>test-object1.txt</Key>
+
+        </Object>
+
+        <Object>
+
+        <Key>test-object2.txt</Key>
+
+        </Object>
+
+        </Delete>
+
+        ```
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Deleted>
+
+        <Key>test-object1.txt</Key>
+
+        </Deleted>
+
+        <Deleted>
+
+        <Key>test-object2.txt</Key>
+
+        </Deleted>
+
+        </DeleteResult>
+
+        ```'
+    DeleteObject:
+      method: delete
+      resourcePath: /object
+      description: Delete an object
+    DeleteObjectStorageCORS:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+      description: Delete all CORS rules of an object storage (bucket)
+    DeleteObjectStorageCORSLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}/cors
+      description: (To be deprecated) Delete CORS configuration of an object storage (bucket)
+    DeleteObjectStorageLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: (To be deprecated) Delete an object storage (bucket)
+    DeleteObjects:
+      method: delete
+      resourcePath: /objects
+      description: Delete child objects along with the given object
+    DeleteProvisioningLog:
+      method: delete
+      resourcePath: /provisioning/log/{specId}
+      description: 'Remove all provisioning history data for a specific VM specification.
+
+        This operation permanently deletes historical failure and success records:
+
+
+        **Warning**: This action is irreversible and will remove:
+
+        - All failure and success statistics
+
+        - Historical error messages and troubleshooting data
+
+        - Risk analysis baseline for future deployments
+
+        - Failure pattern analysis data
+
+
+        **When to Use:**
+
+        - **Data Cleanup**: Remove outdated or irrelevant provisioning history
+
+        - **Fresh Start**: Clear history after infrastructure changes that resolve previous issues
+
+        - **Privacy Compliance**: Remove logs containing sensitive error information
+
+        - **Storage Management**: Clean up logs to manage kvstore space
+
+
+        **Impact on System:**
+
+        - Future risk analysis for this spec will have no historical baseline
+
+        - MCI review process will not show historical warnings for this spec
+
+        - Provisioning reliability metrics will be reset to zero'
+    DeleteRequest:
       method: delete
       resourcePath: /request/{reqId}
-      description: "Delete details of a specific request"
-    Getconnconfig:
+      description: Delete details of a specific request
+    DeleteScheduleRegisterCspResources:
+      method: delete
+      resourcePath: /registerCspResources/schedule/{jobId}
+      description: 'Stop and permanently delete a scheduled CSP resource registration job
+
+
+        **Warning:** This operation is irreversible!
+
+        - Job will be stopped immediately
+
+        - All job data and execution history will be deleted
+
+        - Cannot be recovered after deletion
+
+
+        **Alternatives:**
+
+        - To temporarily stop: Use `/pause` endpoint instead
+
+        - To keep history: Set `enabled: false` via PUT endpoint'
+    DeleteScheduleRegisterCspResourcesAll:
+      method: delete
+      resourcePath: /registerCspResources/schedule
+      description: '⚠️ **DANGER: This operation deletes ALL scheduled jobs in the system!**
+
+
+        **⚠️ CRITICAL WARNINGS:**
+
+        - This will PERMANENTLY DELETE **ALL** scheduled jobs across all namespaces
+
+        - All job execution history will be lost
+
+        - This operation is IRREVERSIBLE and cannot be undone
+
+        - Use with EXTREME CAUTION in production environments
+
+
+        **Use Cases:**
+
+        - Cleaning up test/development environments
+
+        - Emergency shutdown of all scheduled operations
+
+        - System maintenance or reset
+
+
+        **Safer Alternatives:**
+
+        - Delete individual jobs: Use `DELETE /registerCspResources/schedule/{jobId}`
+
+        - Temporarily stop all jobs: Pause each job individually via `/pause` endpoint
+
+        - Disable without deleting: Update each job with `enabled: false`
+
+
+        **Response Information:**
+
+        - Returns the count of deleted jobs
+
+        - Returns 200 even if no jobs were found (count will be 0)'
+    DeleteSecurityGroupTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+      description: Delete a specific SecurityGroup Template.
+    DeleteSiteToSiteVpn:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn/{vpnId}
+      description: 'Delete a site-to-site VPN
+
+
+        - Note: A one-time retry is performed to handle transient failures caused by CSP-internal timing issues between dependent resources.
+
+        '
+    DeleteSqlDb:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
+      description: Delete a SQL datatbase
+    DeleteVNetTemplate:
+      method: delete
+      resourcePath: /ns/{nsId}/template/vNet/{templateId}
+      description: Delete a specific vNet Template.
+    DeleteVersionedObject:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions/{objectKey}
+      description: 'Delete a specific version of an object in an object storage (bucket)
+
+
+        **Note: **
+
+        - If no version is specified, we will define how it behaves and update it when necessary.
+
+        '
+    DeleteVersionedObjectLagacy:
+      method: delete
+      resourcePath: /resources/objectStorage/{objectStorageName}/versions/{objectKey}
+      description: (To be deprecated) Delete a specific version of an object in an object storage (bucket)
+    DeleteVmCommandStatus:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatus/{index}
+      description: Delete a specific command status record by index for a VM
+    DeleteVmCommandStatusByCriteria:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatus
+      description: Delete multiple command status records for a VM based on filtering criteria
+    DeleteVmSshHostKey:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/sshHostKey
+      description: Reset the stored SSH host key for a specific VM. This should be used when the VM's host key has legitimately changed (e.g., after VM recreation) and you trust the new key. The next SSH connection will store the new host key (TOFU).
+    DeregisterCustomImage:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/customImage/{customImageId}
+      description: Deregister customImage from Spider and TB without deleting the actual CSP resource
+    DeregisterDataDisk:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/dataDisk/{dataDiskId}
+      description: Deregister Data Disk from Spider and TB without deleting the actual CSP resource
+    DeregisterInfraNode:
+
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/infra/{mciId}/node/{vmId}
+      description: Deregister VM from Spider and TB without deleting the actual CSP resource
+    DeregisterSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/securityGroup/{securityGroupId}
+      description: Deregister Security Group from Spider and TB without deleting the actual CSP resource
+    DeregisterSshKey:
+      method: delete
+      resourcePath: /ns/{nsId}/deregisterResource/sshKey/{sshKeyId}
+      description: Deregister SSH Key from Spider and TB without deleting the actual CSP resource
+    ExistObjectStorageLagacy:
+      method: head
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: (To be deprecated) Check existence of an object storage (bucket)
+    FetchImages:
+      method: post
+      resourcePath: /fetchImages
+      description: 'Fetch images waiting for completion.
+
+
+        **Provider Selection Options:**
+
+        - `targetProviders`: Specify exact providers to fetch (e.g., ["aws", "gcp"]). When set, only these providers are processed and `excludedProviders` is ignored.
+
+        - `excludedProviders`: Specify providers to skip (e.g., ["azure"]). Only used when `targetProviders` is not set.
+
+        - `regionAgnosticProviders`: Providers where images are shared across regions (e.g., ["gcp", "tencent"]). Only one region will be fetched per provider.
+
+
+        **Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded).'
+    FetchImagesAsync:
+      method: post
+      resourcePath: /fetchImagesAsync
+      description: 'Fetch images in the background without waiting for completion.
+
+
+        **Provider Selection Options:**
+
+        - `targetProviders`: Specify exact providers to fetch (e.g., ["aws", "gcp"]). When set, only these providers are processed and `excludedProviders` is ignored.
+
+        - `excludedProviders`: Specify providers to skip (e.g., ["azure"]). Only used when `targetProviders` is not set.
+
+        - `regionAgnosticProviders`: Providers where images are shared across regions (e.g., ["gcp", "tencent"]). Only one region will be fetched per provider.
+
+
+        **Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded).'
+    FetchPrice:
+      method: post
+      resourcePath: /fetchPrice
+      description: Fetch price from all CSP connections and update the price information for associated specs in the system.
+    FetchSpecs:
+      method: post
+      resourcePath: /fetchSpecs
+      description: 'Fetch specs from CSPs and register them in the system.
+
+
+        **Provider Selection Options:**
+
+        - `targetProviders`: Specify exact providers to fetch (e.g., ["aws", "gcp"]). When set, only these providers are processed and `excludedProviders` is ignored.
+
+        - `excludedProviders`: Specify providers to skip (e.g., ["azure"]). Only used when `targetProviders` is not set.
+
+        - `regionAgnosticProviders`: Providers where specs are shared across regions (e.g., ["gcp", "tencent"]). Only one region will be fetched per provider.
+
+
+        **Note:** `regionAgnosticProviders` should only contain providers that are also in `targetProviders` (or not excluded).'
+    FilterSpecsByRange:
+      method: post
+      resourcePath: /ns/{nsId}/resources/filterSpecsByRange
+      description: Filter specs by range. Use limit field to control the maximum number of results. If limit is 0 or not specified, returns all matching results.
+    ForwardAnyReqToAny:
+      method: post
+      resourcePath: /forward/{path}
+      description: Forward any (GET) request to CB-Spider
+    GeneratePresignedDownloadURLLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/presigned/download/{objectStorageName}/{objectKey}
+      description: '(To be deprecated) Generate a presigned URL for downloading an object from a bucket
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `PresignedURLResult`
+
+        - The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)
+
+        - The generated presigned URL can be used to download the object directly without further authentication
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <PresignedURLResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>
+
+        <Expires>3600</Expires>
+
+        <Method>GET</Method>
+
+        </PresignedURLResult>
+
+        ```'
+    GeneratePresignedURL:
+      method: post
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}/presignedUrl
+      description: 'Generate a presigned URL for uploading  or downloading an object to an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The generated presigned URL can be used to upload the object directly without further authentication
+
+        - The expiration time is specified in seconds (default: 3600 seconds)
+
+
+        **Example Usage: Upload**
+
+        ```bash
+
+        # Using the presigned URL to upload a file
+
+        curl -i -H "Content-Type: text/plain" -X PUT "<PRESIGNED_URL>" --data-binary "@local-file.txt"
+
+        ```
+
+
+        **Example Usage: download**
+
+        ```bash
+
+        # Using the presigned URL to download a file
+
+        curl -X GET "<PRESIGNED_URL>" -o downloaded-file.txt
+
+        ```'
+    GeneratePresignedUploadURLLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/presigned/upload/{objectStorageName}/{objectKey}
+      description: '(To be deprecated) Generate a presigned URL for uploading an object to a bucket
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `PresignedURLResult`
+
+        - The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)
+
+        - The generated presigned URL can be used to upload the object directly without further authentication
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <PresignedURLResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>
+
+        <Expires>3600</Expires>
+
+        <Method>PUT</Method>
+
+        </PresignedURLResult>
+
+        ```'
+    GetAllBenchmark:
+      method: post
+      resourcePath: /ns/{nsId}/benchmarkAll/infra/{mciId}
+      description: Run MCI benchmark for all performance metrics and return results
+    GetAllConfig:
+      method: get
+      resourcePath: /config
+      description: List all configs
+    GetAllCustomImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/customImage
+      description: List all customImages or customImages' ID
+    GetAllDataDisk:
+      method: get
+      resourcePath: /ns/{nsId}/resources/dataDisk
+      description: List all Data Disks or Data Disks' ID
+    GetAllImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/image
+      description: List all images or images' ID
+    GetAllK8sCluster:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster
+      description: List all K8sClusters or K8sClusters' ID
+    GetAllInfra:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra
+      description: List all MCIs or MCIs' ID
+    GetAllInfraDynamicTemplate:
+
+      method: get
+      resourcePath: /ns/{nsId}/template/infra
+      description: 'List all MCI Dynamic Templates in a namespace.
+
+        Optionally filter by keyword matching against template name or description (case-insensitive).'
+    GetAllInfraPolicy:
+
+      method: get
+      resourcePath: /ns/{nsId}/policy/infra
+      description: List all MCI policies
+    GetAllNLB:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb
+      description: List all NLBs or NLBs' ID
+    GetAllNs:
+      method: get
+      resourcePath: /ns
+      description: List all namespaces or namespaces' ID
+    GetAllRequests:
+      method: get
+      resourcePath: /requests
+      description: Get details of all requests with optional filters.
+    GetAllSecurityGroup:
+      method: get
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: List all Security Groups or Security Groups' ID
+    GetAllSecurityGroupTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/securityGroup
+      description: 'List all SecurityGroup Templates in a namespace.
+
+        Optionally filter by keyword matching against template name or description (case-insensitive).'
+    GetAllSiteToSiteVpn:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn
+      description: Get all site-to-site VPNs
+    GetAllSqlDb:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sqlDb
+      description: Get all SQL Databases (TBD)
+    GetAllSshKey:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: List all SSH Keys or SSH Keys' ID
+    GetAllSubnet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
+      description: List all subnets
+    GetAllVNet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: List all VNets or VNets' ID
+    GetAllVNetTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/vNet
+      description: 'List all vNet Templates in a namespace.
+
+        Optionally filter by keyword matching against template name or description (case-insensitive).'
+    GetAvailableK8sNodeImage:
+      method: get
+      resourcePath: /availableK8sNodeImage
+      description: (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
+    GetAvailableK8sVersion:
+      method: get
+      resourcePath: /availableK8sVersion
+      description: Get available kubernetes cluster version
+    GetAvailableRegionZonesForSpec:
+      method: post
+      resourcePath: /availableRegionZonesForSpec
+      description: Query the availability of a specific spec across all regions/zones
+    GetAvailableRegionZonesForSpecList:
+      method: post
+      resourcePath: /availableRegionZonesForSpecList
+      description: Query the availability for multiple specs in parallel and return batch results
+    GetAvailableZonesForSpec:
+      method: get
+      resourcePath: /availableZonesForSpec
+      description: Query verified zones for a spec based on connection configs. Returns zones that are both verified and available for the specified spec. For Alibaba Cloud, additional CSP API filtering is applied.
+    GetBastionNodes:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{targetVmId}/bastion
+      description: Get bastion nodes for a VM
+    GetBenchmark:
+      method: post
+      resourcePath: /ns/{nsId}/benchmark/infra/{mciId}
+      description: Run MCI benchmark for a single performance metric and return results
+    GetCloudInfo:
+      method: get
+      resourcePath: /cloudInfo
+      description: Get cloud information
+    GetCmdInfraStream:
+
+      method: get
+      resourcePath: /ns/{nsId}/stream/cmd/infra/{mciId}
+      description: 'Subscribe to Server-Sent Events (SSE) for real-time command execution logs.
+
+        Use the xRequestId returned from POST /ns/{nsId}/cmd/mci/{mciId}?async=true to connect.
+
+        Events: CommandStatus (status transitions), CommandLog (stdout/stderr lines), CommandDone (terminal).'
+    GetConfig:
+      method: get
+      resourcePath: /config/{configId}
+      description: Get config
+    GetConnConfig:
       method: get
       resourcePath: /connConfig/{connConfigName}
-      description: "Get registered ConnConfig info"
-    Getsystemlabelinfo:
+      description: Get registered ConnConfig info
+    GetConnConfigList:
       method: get
-      resourcePath: /labelInfo
-      description: "Return LabelTypes and system defined label keys with example"
-    Postmcnlb:
-      method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/mcSwNlb
-      description: "Create a special purpose MCI for NLB and depoly and setting SW NLB"
-    Getmcipolicy:
+      resourcePath: /connConfig
+      description: List all registered ConnConfig
+    FilterConnConfigByCredentialHolder:
       method: get
-      resourcePath: /ns/{nsId}/policy/mci/{mciId}
-      description: "Get MCI Policy"
-    Postmcipolicy:
-      method: post
-      resourcePath: /ns/{nsId}/policy/mci/{mciId}
-      description: "Create MCI Automation policy"
-    Delmcipolicy:
-      method: delete
-      resourcePath: /ns/{nsId}/policy/mci/{mciId}
-      description: "Delete MCI Policy"
-    Postutiltodesignvnet:
-      method: post
-      resourcePath: /util/vNet/design
-      description: "Design VNet and subnets based on user-friendly properties"
-    Registercspnativeresourcesall:
-      method: post
-      resourcePath: /registerCspResourcesAll
-      description: "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from all Clouds to CB-Tumblebug"
-    Delmci:
-      method: delete
-      resourcePath: /ns/{nsId}/mci/{mciId}
-      description: "Delete MCI"
-    Getmci:
+      resourcePath: /connConfig
+      description: Filter connection configs by credential holder name (queryParams.filterCredentialHolder)
+    GetControlK8sCluster:
       method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}
-      description: "Get MCI object (option: status, accessInfo, vmId)"
-    Getrequeststatusofsitetositevpn:
+      resourcePath: /ns/{nsId}/control/k8sCluster/{k8sClusterId}
+      description: Control the creation of K8sCluster (continue, withdraw)
+    GetControlInfra:
+
       method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/vpn/{vpnId}/request/{requestId}
-      description: "Check the status of a specific request by its ID"
-    Getreadyz:
+      resourcePath: /ns/{nsId}/control/infra/{mciId}
+      description: Control the lifecycle of MCI (refine, suspend, resume, reboot, terminate)
+    GetControlInfraNode:
+
+      method: get
+      resourcePath: /ns/{nsId}/control/infra/{mciId}/node/{vmId}
+      description: Control the lifecycle of VM (suspend, resume, reboot, terminate)
+    GetCredentialHolder:
+      method: get
+      resourcePath: /credentialHolder/{holderId}
+      description: Get credential holder info derived from registered connection configs.
+    GetCredentialHolderList:
+      method: get
+      resourcePath: /credentialHolder
+      description: 'List all credential holders derived from registered connection configs.
+
+        Each holder includes associated providers, connection counts, and verification status.'
+    GetCustomImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/customImage/{customImageId}
+      description: Get customImage
+    GetDataDisk:
+      method: get
+      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+      description: Get Data Disk
+    GetDataObjectInfo:
+      method: head
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
+      description: 'Get object info from an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - This API retrieves the metadata of an object without downloading the actual content
+
+        - Returns metadata in response headers (Content-Length, Content-Type, ETag, Last-Modified)'
+    GetDataObjectInfoLagacy:
+      method: head
+      resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
+      description: '(To be deprecated) Get an object info from a bucket
+
+
+        **Important Notes:**
+
+        - The generated `Download file` link in Swagger UI may not work because this API get the object metadata only.'
+    GetExecutionTask:
+      method: get
+      resourcePath: /ns/{nsId}/cmd/infra/{mciId}/task/{taskId}
+      description: Get detailed information about a specific execution task by taskId
+    GetFetchImagesAsyncResult:
+      method: get
+      resourcePath: /fetchImagesResult
+      description: Get detailed results from the last asynchronous image fetch operation
+    GetGlobalDnsRecord:
+      method: get
+      resourcePath: /resources/globalDns/record
+      description: Get DNS records for a domain from Route53. Includes routing policy and geoproximity info.
+    GetHostedZones:
+      method: get
+      resourcePath: /resources/globalDns/hostedZone
+      description: List all hosted zones available in Route53
+    GetImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: GetImage returns an image object if there are matched images for the given namespace and imageKey(imageId)
+    GetK8sCluster:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}
+      description: Get K8sCluster
+    GetK8sClusterInfo:
+      method: get
+      resourcePath: /k8sClusterInfo
+      description: Get kubernetes cluster information
+    GetK8sClusterToken:
+      method: get
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/token
+      description: 'Get an access token for the specified K8sCluster.
+
+        Only applicable to CSPs that use exec-based authentication (e.g., GCP GKE, AWS EKS).'
+    GetLabels:
+      method: get
+      resourcePath: /label/{labelType}/{uid}
+      description: Get labels for a resource identified by its uid
+    GetLatencyBenchmark:
+      method: get
+      resourcePath: /ns/{nsId}/benchmarkLatency/infra/{mciId}
+      description: Run MCI benchmark for network latency
+    GetInfra:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}
+      description: 'Get MCI object (option: status, accessInfo, vmId)'
+    GetInfraAssociatedResources:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/associatedResources
+      description: Get associated resource ID list for a given MCI (VNet, Subnet, SecurityGroup, SSHKey, etc.)
+    GetInfraDynamicTemplate:
+
+      method: get
+      resourcePath: /ns/{nsId}/template/infra/{templateId}
+      description: Retrieve a specific MCI Dynamic Template by ID.
+    GetInfraExecutionTasks:
+
+      method: get
+      resourcePath: /ns/{nsId}/cmd/infra/{mciId}/task
+      description: List all running and completed execution tasks for a specific MCI. These tasks can be cancelled if still in progress. The task list is based on persistent VM command status records.
+    GetInfraGroupIds:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodegroup
+      description: List SubGroup IDs in a specified MCI
+    GetInfraGroupNodes:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodegroup/{subgroupId}
+      description: List VMs with a SubGroup label in a specified MCI
+    GetInfraHandlingCommandCount:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/handlingCount
+      description: Get the number of commands currently in 'Handling' status for all VMs in an MCI. Returns per-VM counts and total count.
+    GetInfraPolicy:
+
+      method: get
+      resourcePath: /ns/{nsId}/policy/infra/{mciId}
+      description: Get MCI Policy
+    GetInfraReqFromInfra:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/configCopy
+      description: 'Reconstruct an MCI dynamic creation request body from an existing MCI''s information.
+
+        Returns a dynamic request format where networking resources (vNet, subnet, SG, sshKey)
+
+        are auto-created, making it easy to clone or recreate a similar MCI configuration.
+
+
+        **Template Option:**
+
+        When the `template` query parameter is provided, the extracted configuration is
+
+        saved as a reusable MCI Dynamic Template with the given name.'
+    GetInfraNode:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}
+      description: Get VM in specified MCI
+    GetMonitorData:
+      method: get
+      resourcePath: /ns/{nsId}/monitoring/infra/{mciId}/metric/{metric}
+      description: Get monitoring data of specified MCI for specified monitoring metric (cpu, memory, disk, network)
+    GetNLB:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}
+      description: Get NLB
+    GetNLBHealth:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}/healthz
+      description: Get NLB Health
+    GetNs:
+      method: get
+      resourcePath: /ns/{nsId}
+      description: Get namespace
+    GetObject:
+      method: get
+      resourcePath: /object
+      description: Get value of an object
+    GetObjectStorage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+      description: Get details of an object storage (bucket)
+    GetObjectStorageCORS:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+      description: Get CORS configuration of an object storage (bucket)
+    GetObjectStorageCORSLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/cors
+      description: '(To be deprecated) Get CORS configuration of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `CORSConfiguration`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <CORSRule>
+
+        <AllowedOrigin>*</AllowedOrigin>
+
+        <AllowedMethod>GET</AllowedMethod>
+
+        <AllowedMethod>PUT</AllowedMethod>
+
+        <AllowedMethod>POST</AllowedMethod>
+
+        <AllowedMethod>DELETE</AllowedMethod>
+
+        <AllowedHeader>*</AllowedHeader>
+
+        <ExposeHeader>ETag</ExposeHeader>
+
+        <ExposeHeader>x-amz-server-side-encryption</ExposeHeader>
+
+        <ExposeHeader>x-amz-request-id</ExposeHeader>
+
+        <ExposeHeader>x-amz-id-2</ExposeHeader>
+
+        <MaxAgeSeconds>3000</MaxAgeSeconds>
+
+        </CORSRule>
+
+        </CORSConfiguration>
+
+        ```
+
+
+        **Error Response Example (if CORS not configured):**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <Error>
+
+        <Code>NoSuchCORSConfiguration</Code>
+
+        <Message>The CORS configuration does not exist</Message>
+
+        <Resource>/example-bucket</Resource>
+
+        <RequestId>656c76696e6727732072657175657374</RequestId>
+
+        </Error>
+
+        ```'
+    GetObjectStorageLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}
+      description: '(To be deprecated) Get details of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `ListBucketResult`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Name>spider-test-bucket</Name>
+
+        <Prefix></Prefix>
+
+        <Marker></Marker>
+
+        <MaxKeys>1000</MaxKeys>
+
+        <IsTruncated>false</IsTruncated>
+
+        </ListBucketResult>
+
+        ```'
+    GetObjectStorageLocation:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/location
+      description: Get the location of an object storage (bucket)
+    GetObjectStorageLocationLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/location
+      description: '(To be deprecated) Get the location of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `LocationConstraint`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">ap-northeast-2</LocationConstraint>
+
+        ```'
+    GetObjectStorageSupport:
+      method: get
+      resourcePath: /objectStorage/support
+      description: 'Get CSP support information for object storage features (CORS, Versioning)
+
+        If cspType query parameter is provided, returns support information for that specific CSP
+
+        If cspType is not provided, returns support information for all CSPs'
+    GetObjectStorageVersioning:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
+      description: Get versioning configuration of an object storage (bucket)
+    GetObjectStorageVersioningLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/versioning
+      description: '(To be deprecated) Get versioning status of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `VersioningConfiguration`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Status>Enabled</Status>
+
+        </VersioningConfiguration>
+
+        ```'
+    GetObjects:
+      method: get
+      resourcePath: /objects
+      description: List all objects for a given key
+    GetProviderList:
+      method: get
+      resourcePath: /provider
+      description: List all registered Providers
+    GetProvisioningLog:
+      method: get
+      resourcePath: /provisioning/log/{specId}
+      description: 'Retrieve detailed provisioning history for a specific VM specification including success/failure patterns and risk analysis.
+
+        This endpoint provides comprehensive insights into provisioning reliability:
+
+
+        **Historical Data Includes:**
+
+        - Success and failure counts with timestamps
+
+        - CSP-specific error messages and failure patterns
+
+        - Image compatibility tracking across different attempts
+
+        - Failure rate analysis and risk assessment
+
+        - Regional and provider-specific reliability metrics
+
+
+        **Use Cases:**
+
+        - **Pre-deployment Risk Assessment**: Check if a spec has historical failures before creating MCI
+
+        - **Troubleshooting**: Analyze failure patterns to identify root causes
+
+        - **Capacity Planning**: Understand reliability patterns for different specs and regions
+
+        - **Cost Optimization**: Avoid specs with high failure rates that waste resources
+
+
+        **Response Details:**
+
+        - `failureCount`: Total number of provisioning failures
+
+        - `successCount`: Number of successes (only tracked after failures occur)
+
+        - `failureImages`: List of CSP images that failed with this spec
+
+        - `successImages`: List of CSP images that succeeded with this spec
+
+        - `failureMessages`: Detailed error messages from CSP
+
+        - `lastUpdated`: Timestamp of most recent provisioning attempt'
+    GetPublicKeyForCredentialEncryption:
+      method: get
+      resourcePath: /credential/publicKey
+      description: Generates an RSA key pair using a 4096-bit key size with the RSA algorithm. The public key is generated using the RSA algorithm with OAEP padding and SHA-256 as the hash function. This key is used to encrypt an AES key that will be used for hybrid encryption of credentials.
+    GetReadyz:
       method: get
       resourcePath: /readyz
-      description: "Check Tumblebug is ready"
-    Setbastionnodes:
-      method: put
-      resourcePath: /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion/{bastionVmId}
-      description: "Set bastion nodes for a VM"
-    Postmcidynamic:
+      description: Check Tumblebug is ready. Returns ready status and initialization status.
+    GetRegion:
+      method: get
+      resourcePath: /provider/{providerName}/region/{regionName}
+      description: Get registered region info
+    GetRegions:
+      method: get
+      resourcePath: /provider/{providerName}/region
+      description: Get registered region info
+    GetRequest:
+      method: get
+      resourcePath: /request/{reqId}
+      description: Get details of a specific request
+    GetRequestStatusOfSiteToSiteVpn:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn/{vpnId}/request/{requestId}
+      description: Check the status of a specific request by its ID
+    GetRequiredK8sSubnetCount:
+      method: get
+      resourcePath: /requiredK8sSubnetCount
+      description: Get the required subnet count to create a K8sCluster
+    GetResourcesByLabelSelector:
+      method: get
+      resourcePath: /resources/{labelType}
+      description: 'Get resources based on a label selector. The label selector supports the following operators:
+
+        - `=` : Selects resources where the label key equals the specified value (e.g., `env=production`).
+
+        - `!=` : Selects resources where the label key does not equal the specified value (e.g., `tier!=frontend`).
+
+        - `in` : Selects resources where the label key is in the specified set of values (e.g., `region in (us-west, us-east)`).
+
+        - `notin` : Selects resources where the label key is not in the specified set of values (e.g., `env notin (production, staging)`).
+
+        - `exists` : Selects resources where the label key exists (e.g., `env exists`).
+
+        - `!exists` : Selects resources where the label key does not exist (e.g., `env !exists`).'
+    GetScheduleRegisterCspResourcesList:
+      method: get
+      resourcePath: /registerCspResources/schedule
+      description: Get a list of all scheduled CSP resource registration jobs (jobs are not scoped to namespaces)
+    GetScheduleRegisterCspResourcesStatus:
+      method: get
+      resourcePath: /registerCspResources/schedule/{jobId}
+      description: 'Get the current status of a specific scheduled CSP resource registration job
+
+
+        **Response Fields Explanation:**
+
+        - `status`: Current job state (Scheduled/Executing/Stopped)
+
+        - `enabled`: Whether job is active (can be paused with false)
+
+        - `executionCount`: Total number of executions attempted
+
+        - `successCount`: Number of successful executions
+
+        - `failureCount`: Number of failed executions
+
+        - `consecutiveFailures`: Current streak of failures (resets on success)
+
+        - `autoDisabled`: True if job was auto-disabled due to 5+ consecutive failures
+
+        - `lastExecutedAt`: Timestamp of most recent execution
+
+        - `nextExecutionAt`: Scheduled time for next execution
+
+        - `lastError`: Error message from most recent failure (empty if success)
+
+        - `lastResult`: Result message from most recent execution
+
+
+        **Monitoring Recommendations:**
+
+        - Check `consecutiveFailures` - alert if >= 3
+
+        - Monitor `autoDisabled` - requires manual intervention if true
+
+        - Compare `successCount` vs `failureCount` for reliability metrics'
+    GetSecurityGroup:
+      method: get
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: Get Security Group
+    GetSecurityGroupTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+      description: Retrieve a specific SecurityGroup Template by ID.
+    GetSiteToSiteVpn:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn/{vpnId}
+      description: Get resource info of a site-to-site VPN
+    GetSitesInInfra:
+
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/site
+      description: Get sites in MCI
+    GetSpec:
+      method: get
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: Get spec
+    GetSqlDb:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
+      description: Get resource info of a SQL datatbase
+    GetSshKey:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: Get SSH Key
+    GetSubnet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
+      description: Get Subnet
+    GetSystemLabelInfo:
+      method: get
+      resourcePath: /labelInfo
+      description: Return LabelTypes and system defined label keys with example
+    GetVNet:
+      method: get
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+      description: Get VNet
+    GetVNetTemplate:
+      method: get
+      resourcePath: /ns/{nsId}/template/vNet/{templateId}
+      description: Retrieve a specific vNet Template by ID.
+    GetVmCommandStatus:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatus/{index}
+      description: Get a specific command status record by index for a VM
+    GetVmDataDisk:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/dataDisk
+      description: Get available dataDisks for a VM
+    GetVmHandlingCommandCount:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/handlingCount
+      description: Get the number of commands currently in 'Handling' status for a specific VM. Optimized for frequent polling.
+    GetVmSshHostKey:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/sshHostKey
+      description: Get the stored SSH host key information for a specific VM. This is used for TOFU (Trust On First Use) verification.
+    InitAllConfig:
+      method: delete
+      resourcePath: /config
+      description: Init all configs
+    InitConfig:
+      method: delete
+      resourcePath: /config/{configId}
+      description: Init config
+    InspectResources:
       method: post
-      resourcePath: /ns/{nsId}/mciDynamic
-      description: "Create MCI Dynamically from common spec and image"
-    Postinfradynamicreview:
+      resourcePath: /inspectResources
+      description: Inspect Resources (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug, CB-Spider, CSP
+    InspectResourcesOverview:
+      method: get
+      resourcePath: /inspectResourcesOverview
+      description: Inspect Resources Overview (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug and CSP for all connections
+    ListDataObjects:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object
+      description: List all objects in an object storage (bucket)
+    ListObjectStorages:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage
+      description: Get the list of object storages (buckets)
+    ListObjectStoragesLagacy:
+      method: get
+      resourcePath: /resources/objectStorage
+      description: '(To be deprecated) Get the list of all object storages (buckets)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `ListAllMyBucketsResult`
+
+        - The response includes xmlns attribute: `xmlns="http://s3.amazonaws.com/doc/2006-03-01/"`
+
+        - Swagger UI may show `resource.ListAllMyBucketsResult` due to rendering limitations
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Owner>
+
+        <ID>aws-ap-northeast-2</ID>
+
+        <DisplayName>aws-ap-northeast-2</DisplayName>
+
+        </Owner>
+
+        <Buckets>
+
+        </Buckets>
+
+        </ListAllMyBucketsResult>
+
+        ```'
+    ListObjectVersions:
+      method: get
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions
+      description: List all versions of objects in an object storage (bucket)
+    ListObjectVersionsLagacy:
+      method: get
+      resourcePath: /resources/objectStorage/{objectStorageName}/versions
+      description: '(To be deprecated) List object versions in an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The actual response will be XML format with root element `ListVersionsResult`
+
+
+        **Actual XML Response Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Name>spider-test-bucket</Name>
+
+        <Prefix></Prefix>
+
+        <KeyMarker></KeyMarker>
+
+        <VersionIdMarker></VersionIdMarker>
+
+        <NextKeyMarker></NextKeyMarker>
+
+        <NextVersionIdMarker></NextVersionIdMarker>
+
+        <MaxKeys>1000</MaxKeys>
+
+        <IsTruncated>false</IsTruncated>
+
+        <Version>
+
+        <Key>test-file.txt</Key>
+
+        <VersionId>yb4PgjnFVD2LfRZHXBjjsHBkQRHlu.TZ</VersionId>
+
+        <IsLatest>true</IsLatest>
+
+        <LastModified>2025-09-04T04:24:12Z</LastModified>
+
+        <ETag>23228a38faecd0591107818c7281cece</ETag>
+
+        <Size>23</Size>
+
+        <StorageClass>STANDARD</StorageClass>
+
+        <Owner>
+
+        <ID>aws-config01</ID>
+
+        <DisplayName>aws-config01</DisplayName>
+
+        </Owner>
+
+        </Version>
+
+        </ListVersionsResult>
+
+        ```'
+    ListVmCommandStatus:
+      method: get
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/commandStatus
+      description: List command status records for a VM with various filtering options
+    GetAssetsSummary:
+      method: get
+      resourcePath: /assetsSummary
+      description: "Returns CSP-wise summary of specs and images in DB for a namespace,
+        including priced/unpriced spec counts. (CB-TB v0.12.6+). Used by FR-006-08
+        Setup Status > loadAssets card. query: nsId (default=system)."
+    LoadAssets:
+      method: get
+      resourcePath: /loadAssets
+      description: Load Common Resources from internal asset files (Spec, Image). By default, Azure images are excluded for faster initialization. Use includeAzure=true to fetch Azure images (may take 40+ minutes).
+    LookupImage:
+      method: post
+      resourcePath: /lookupImage
+      description: Lookup image (for debugging purposes)
+    LookupImageList:
+      method: post
+      resourcePath: /lookupImages
+      description: Lookup image list (for debugging purposes)
+    LookupSpec:
+      method: post
+      resourcePath: /lookupSpec
+      description: Lookup spec (for debugging purposes)
+    LookupSpecList:
+      method: post
+      resourcePath: /lookupSpecs
+      description: Lookup spec list (for debugging purposes)
+    MergeCSPResourceLabel:
+      method: put
+      resourcePath: /mergeCSPLabel/{labelType}/{uid}
+      description: Fetch the labels in the CSP and merge them with the existing labels
+    PostBuildAgnosticImage:
+      method: post
+      resourcePath: /ns/{nsId}/buildAgnosticImage
+      description: Creates an MCI infrastructure, executes post-deployment commands, creates snapshots from each subgroup, and optionally cleans up the MCI. This is a complete workflow for building CSP-agnostic custom images.
+    PostCmdK8sCluster:
+      method: post
+      resourcePath: /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}
+      description: 'Send a command to specified Container in K8sCluster
+
+        [note] This feature is not intended for general use
+
+        This API is provided as an exceptional and limited function for specific purposes such as migration.
+
+        Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.'
+    PostCmdInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/cmd/infra/{mciId}
+      description: 'Send a command to specified MCI. Use query parameters to target specific subGroup or VM.
+
+        When async=true, returns immediately with xRequestId and streams results via SSE at GET /stream/ns/{nsId}/cmd/mci/{mciId}?xRequestId={xRequestId}'
+    PostConfig:
+      method: post
+      resourcePath: /config
+      description: Create or Update config (TB_SPIDER_REST_URL, TB_DRAGONFLY_REST_URL, ...)
+    PostCustomImage:
+      method: post
+      resourcePath: /ns/{nsId}/resources/customImage
+      description: Register existing Custom Image in a CSP (option=register)
+    PostDataDisk:
+      method: post
+      resourcePath: /ns/{nsId}/resources/dataDisk
+      description: Create Data Disk
+    PostDownloadFileFromInfraNode:
+
+      method: post
+      resourcePath: /ns/{nsId}/downloadFile/infra/{mciId}/node/{vmId}
+      description: 'Download a file from a specific VM in MCI via SCP through bastion host.
+
+        The file size should be less than 200MB.'
+    PostFileToK8sCluster:
+      method: post
+      resourcePath: /ns/{nsId}/transferFile/k8sCluster/{k8sClusterId}
+      description: 'Transfer a file to specified Container in K8sCluster. The tar command is required in the container.
+
+        [note] This feature is not intended for general use
+
+        This API is provided as an exceptional and limited function for specific purposes such as migration.
+
+        Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.'
+    PostFileToInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/transferFile/infra/{mciId}
+      description: 'Transfer a file to specified MCI to the specified path.
+
+        The file size should be less than 10MB.
+
+        Not for gerneral file transfer but for specific purpose (small configuration files).'
+    PostFirewallRules:
+      method: post
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules
+      description: 'Add new FirewallRules: Add the provided firewall rules to the existing rules in the Security Group.
+
+        This API will only add new rules without deleting or modifying existing ones.
+
+        If a rule with identical properties already exists, it will be skipped to avoid duplicates.
+
+
+        Usage:
+
+        Use this API to add new firewall rules to a Security Group while preserving existing rules.
+
+        - Only new rules that don''t already exist will be added.
+
+        - Existing rules remain unchanged.
+
+        - If an identical rule already exists, it will be skipped.
+
+
+        Notes:
+
+        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+
+        - The valid port number range is 0 to 65535 (inclusive).
+
+        - "Protocol" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).
+
+        - "Direction" must be either "inbound" or "outbound".
+
+        - "CIDR" is the allowed IP range.'
+    PostImage:
+      method: post
+      resourcePath: /ns/{nsId}/resources/image
+      description: Register image
+    PostInstallBenchmarkAgentToInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/installBenchmarkAgent/infra/{mciId}
+      description: Install the benchmark agent to specified MCI
+    PostInstallMonitorAgentToInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/monitoring/install/infra/{mciId}
+      description: Install monitoring agent (CB-Dragonfly agent) to MCI
+    PostK8sCluster:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster
+      description: Create K8sCluster<br>Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1614
+    PostK8sClusterDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/k8sClusterDynamic
+      description: Create K8sCluster Dynamically from common spec and image
+    PostK8sClusterDynamicCheckRequest:
+      method: post
+      resourcePath: /k8sClusterDynamicCheckRequest
+      description: Check available ConnectionConfig list before create K8sCluster Dynamically from common spec and image
+    PostK8sMultiClusterDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/k8sMultiClusterDynamic
+      description: '(PoC API. For developers only, and do not use in production.)
+
+        Create multiple K8sClusters in parallel from common spec and image.
+
+        If namePrefix is provided, cluster names will be auto-generated as ''{namePrefix}-{csp}-{number}'' (e.g., ''across-aws-1'', ''across-alibaba-2'').
+
+
+        If namePrefix is not provided, each cluster must have a name specified.
+
+
+        **Example request body:**
+
+        ```json
+
+        {
+
+        "namePrefix": "across",
+
+        "clusters": [
+
+        {
+
+        "imageId": "default",
+
+        "specId": "aws+eu-west-2+t3a.xlarge"
+
+        },
+
+        {
+
+        "nodeGroupName": "ng-1",
+
+        "imageId": "default",
+
+        "specId": "azure+germanywestcentral+standard_b4ms"
+
+        },
+
+        {
+
+        "nodeGroupName": "ng-1",
+
+        "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2204-jammy-v20251120",
+
+        "specId": "gcp+europe-west9+e2-highmem-4"
+
+        }
+
+        ]
+
+        }
+
+        ```'
+    PostK8sNodeGroup:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup
+      description: Add a K8sNodeGroup
+    PostK8sNodeGroupDynamic:
+      method: post
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroupDynamic
+      description: Create K8sNodeGroup Dynamically from common spec and image
+    PostMcNLB:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/mcSwNlb
+      description: Create a special purpose MCI for NLB and depoly and setting SW NLB
+    PostInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra
+      description: 'Create MCI with detailed VM specifications and resource configuration.
+
+        This endpoint creates a complete multi-cloud infrastructure by:
+
+        1. **VM Provisioning**: Creates VMs across multiple cloud providers using predefined specs and images
+
+        2. **Resource Management**: Automatically handles VPC/VNet, security groups, SSH keys, and network configuration
+
+        3. **Status Tracking**: Monitors VM creation progress and handles failures based on policy settings
+
+        4. **Post-Deployment**: Optionally installs monitoring agents and executes custom commands
+
+
+        **Key Features:**
+
+        - Multi-cloud VM deployment with heterogeneous configurations
+
+        - Automatic resource dependency management (VPC → Security Group → VM)
+
+        - Built-in failure handling with configurable policies (continue/rollback/refine)
+
+        - Optional CB-Dragonfly monitoring agent installation
+
+        - Post-deployment command execution support
+
+        - Real-time status updates and progress tracking
+
+
+        **VM Lifecycle:**
+
+        1. Creating → Running (successful deployment)
+
+        2. Creating → Failed (deployment error, handled by failure policy)
+
+        3. Running → Terminated (manual or policy-driven cleanup)
+
+
+        **Failure Policies:**
+
+        - `continue`: Keep successful VMs, mark failed ones for later refinement
+
+        - `rollback`: Delete entire MCI if any VM fails (all-or-nothing)
+
+        - `refine`: Automatically clean up failed VMs, keep successful ones
+
+
+        **Resource Requirements:**
+
+        - Valid VM specifications (must exist in system namespace)
+
+        - Valid images (must be available in target CSP regions)
+
+        - Sufficient CSP quotas and permissions
+
+        - Network connectivity between components'
+    PostInfraDynamic:
+
+      method: post
+      resourcePath: /ns/{nsId}/infraDynamic
+      description: 'Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.
+
+        This is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:
+
+
+        **Dynamic Resource Creation:**
+
+        1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace
+
+        2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider
+
+        3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously
+
+        4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically
+
+        5. **Failure Recovery**: Implements configurable failure policies for robust deployment
+
+
+        **Key Advantages Over Static MCI:**
+
+        - **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources
+
+        - **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys
+
+        - **Multi-Cloud Optimization**: Intelligent placement and configuration across providers
+
+        - **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically
+
+        - **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization
+
+
+        **Configuration Process:**
+
+        1. **Resource Discovery**: Use `/recommendSpec` to find suitable VM specifications
+
+        2. **Image Selection**: Use system namespace to discover compatible images
+
+        3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment
+
+        4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration
+
+        5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options
+
+
+        **Failure Policies (PolicyOnPartialFailure):**
+
+        - **`continue`** (default): Create MCI with successful VMs, failed VMs remain for manual refinement
+
+        - **`rollback`**: Delete entire MCI if any VM fails (all-or-nothing deployment)
+
+        - **`refine`**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)
+
+
+        **Deployment Options:**
+
+        - **`hold`**: Create MCI object but hold VM provisioning for manual approval
+
+        - **Normal**: Proceed with immediate VM provisioning after resource creation
+
+
+        **Multi-Cloud Example Configuration:**
+
+        ```json
+
+        {
+
+        "name": "multi-cloud-web-tier",
+
+        "description": "Web application across AWS, Azure, and GCP",
+
+        "policyOnPartialFailure": "refine",
+
+        "vm": [
+
+        {
+
+        "name": "aws-web-servers",
+
+        "subGroupSize": "3",
+
+        "specId": "aws+us-east-1+t3.medium",
+
+        "imageId": "ami-0abcdef1234567890",
+
+        "rootDiskSize": "100",
+
+        "label": {"tier": "web", "provider": "aws"}
+
+        },
+
+        {
+
+        "name": "azure-api-servers",
+
+        "subGroupSize": "2",
+
+        "specId": "azure+eastus+Standard_B2s",
+
+        "imageId": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts",
+
+        "label": {"tier": "api", "provider": "azure"}
+
+        }
+
+        ]
+
+        }
+
+        ```
+
+
+        **Performance Considerations:**
+
+        - VM provisioning occurs in parallel across providers
+
+        - Network resources are created concurrently where possible
+
+        - Large deployments (>10 VMs) automatically use optimized batching
+
+        - Built-in rate limiting prevents CSP API throttling
+
+
+        **Monitoring and Post-Deployment:**
+
+        - Optional CB-Dragonfly monitoring agent installation
+
+        - Custom post-deployment command execution
+
+        - Real-time status tracking and progress updates
+
+        - Automatic resource labeling and metadata management'
+    PostInfraDynamicCheckRequest:
+
+      method: post
+      resourcePath: /infraDynamicCheckRequest
+      description: '**⚠️ DEPRECATED: This endpoint is deprecated and will be removed in a future version. Please use `/mciDynamicReview` instead for comprehensive validation and cost estimation.**
+
+
+        Validate resource availability and discover optimal connection configurations before creating MCI dynamically.
+
+        This endpoint provides comprehensive resource validation and connection discovery for MCI planning:
+
+
+        **Resource Validation Process:**
+
+        1. **Specification Analysis**: Validates that requested common specs exist and are accessible
+
+        2. **Provider Discovery**: Identifies available cloud providers and regions for each specification
+
+        3. **Connectivity Assessment**: Tests connection configurations and CSP API accessibility
+
+        4. **Quota Verification**: Checks available quotas and resource limits where possible
+
+        5. **Compatibility Matrix**: Generates matrix of viable spec-provider-region combinations
+
+
+        **Connection Configuration Discovery:**
+
+        - **Available Providers**: Lists all configured cloud providers (AWS, Azure, GCP, etc.)
+
+        - **Active Regions**: Shows available regions per provider with connectivity status
+
+        - **Specification Mapping**: Maps common specs to provider-specific instance types
+
+        - **Image Compatibility**: Validates image availability across different providers/regions
+
+        - **Network Capabilities**: Identifies supported network features and configurations
+
+
+        **Pre-Deployment Validation:**
+
+        - **Resource Existence**: Confirms all specified resources exist in system namespace
+
+        - **Permission Verification**: Validates CSP credentials and required permissions
+
+        - **API Connectivity**: Tests connection to CSP APIs and service endpoints
+
+        - **Dependency Resolution**: Identifies any missing dependencies or prerequisites
+
+
+        **Optimization Recommendations:**
+
+        - **Cost-Effective Regions**: Suggests regions with lower pricing for specified resources
+
+        - **Performance Optimization**: Recommends regions with better network performance
+
+        - **Availability Zone**: Identifies optimal AZ distribution for high availability
+
+        - **Resource Bundling**: Suggests efficient resource combinations and groupings
+
+
+        **Output Information:**
+
+        - **Connection Candidates**: List of viable connection configurations
+
+        - **Provider Capabilities**: Detailed capabilities matrix per provider
+
+        - **Resource Status**: Real-time availability status for each requested resource
+
+        - **Recommendation Summary**: Actionable recommendations for optimal deployment
+
+
+        **Use Cases:**
+
+        - Pre-validate MCI configuration before expensive deployment operations
+
+        - Discover optimal provider/region combinations for cost or performance
+
+        - Troubleshoot resource availability issues during MCI planning
+
+        - Generate connection configuration templates for standardized deployments
+
+        - Assess infrastructure capacity and planning constraints
+
+
+        **Integration Workflow:**
+
+        1. Use this endpoint to validate and discover connection options
+
+        2. Review recommendations and adjust specifications if needed
+
+        3. Use `/mciDynamicReview` for detailed cost estimation and final validation
+
+        4. Proceed with `/mciDynamic` using validated configuration'
+    PostInfraDynamicFromTemplate:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/template/{templateId}
+      description: 'Create a new MCI by applying an MCI Dynamic Template.
+
+        The template provides the base VM configuration, and the apply request
+
+        allows overriding the MCI name and description.
+
+
+        **Override Behavior (Phase 1):**
+
+        - `name` (required): Name for the new MCI
+
+        - `description` (optional): Overrides the template''s description
+
+        - All other configuration (specs, images, subgroups) comes from the template'
+    PostInfraDynamicReview:
+
       method: post
       resourcePath: /ns/{nsId}/infraDynamicReview
-      description: "Review and validate Infra dynamic request comprehensively before actual provisioning"
+      description: 'Review and validate MCI dynamic request comprehensively before actual provisioning.
+
+        This endpoint performs comprehensive validation of MCI dynamic creation requests without actually creating resources.
+
+        It checks resource availability, validates specifications and images, estimates costs, and provides detailed recommendations.
+
+
+        **Key Features:**
+
+        - Validates all VM specifications and images against CSP availability
+
+        - Provides cost estimation (including partial estimates when some costs are unknown)
+
+        - Identifies potential configuration issues and warnings
+
+        - Recommends optimization strategies
+
+        - Shows provider and region distribution
+
+        - Non-invasive validation (no resources are created)
+
+
+        **Review Status:**
+
+        - `Ready`: All VMs can be created successfully
+
+        - `Warning`: VMs can be created but with configuration warnings
+
+        - `Error`: Critical errors prevent MCI creation
+
+
+        **Use Cases:**
+
+        - Pre-validation before expensive MCI creation
+
+        - Cost estimation and planning
+
+        - Configuration optimization
+
+        - Multi-cloud resource planning'
+    PostInfraDynamicNodeGroupNodeReview:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodeGroupDynamicReview
+      description: 'Review and validate a VM dynamic addition request for an existing MCI before actual provisioning.
+
+        This endpoint provides comprehensive validation for adding new VMs to existing MCIs without actually creating resources.
+
+        It checks resource availability, validates specifications and images, estimates costs, and provides detailed recommendations.
+
+
+        **Key Features:**
+
+        - Validates VM specification and image against CSP availability
+
+        - Checks compatibility with existing MCI configuration
+
+        - Provides cost estimation for the new VM addition
+
+        - Identifies potential configuration issues and warnings
+
+        - Recommends optimization strategies
+
+        - Non-invasive validation (no resources are created)
+
+
+        **Review Status:**
+
+        - `Ready`: VM can be added successfully
+
+        - `Warning`: VM can be added but with configuration warnings
+
+        - `Error`: Critical errors prevent VM addition
+
+
+        **MCI Integration Validation:**
+
+        - Ensures target MCI exists and is in a compatible state
+
+        - Validates network integration possibilities
+
+        - Checks resource naming conflicts
+
+        - Verifies security group and SSH key compatibility
+
+
+        **Use Cases:**
+
+        - Pre-validation before expensive VM addition operations
+
+        - Cost estimation for scaling decisions
+
+        - Configuration optimization before deployment
+
+        - Risk assessment for VM addition to existing infrastructure'
+    PostInfraDynamicTemplate:
+
+      method: post
+      resourcePath: /ns/{nsId}/template/infra
+      description: 'Create a reusable MCI Dynamic Template. Templates store MCI dynamic creation
+
+        request configurations that can be applied later to create MCIs with consistent settings.
+
+
+        **Template Contents:**
+
+        - VM specifications (specId, imageId) for each subgroup
+
+        - Subgroup sizing and naming
+
+        - Network and disk configuration
+
+        - Post-deployment commands
+
+        - Monitoring agent options
+
+
+        Templates can be created manually or extracted from existing MCIs.'
+    PostInfraPolicy:
+
+      method: post
+      resourcePath: /ns/{nsId}/policy/infra/{mciId}
+      description: Create MCI Automation policy
+    PostInfraSnapshot:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/snapshot
+      description: Create snapshots for the first running VM in each subgroup of an MCI in parallel
+    PostInfraNodeGroupDynamic:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodeGroupDynamic
+      description: 'Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management.
+
+        This endpoint provides elastic scaling capabilities for running MCIs:
+
+
+        **Dynamic VM Addition Process:**
+
+        1. **MCI Validation**: Verifies target MCI exists and is in a valid state for expansion
+
+        2. **Resource Discovery**: Resolves common spec and image to provider-specific resources
+
+        3. **Network Integration**: Automatically configures new VMs to use existing MCI network resources
+
+        4. **Subgroup Management**: Creates new subgroups or expands existing ones based on configuration
+
+        5. **Status Synchronization**: Updates MCI status and metadata to reflect new VM additions
+
+
+        **Integration with Existing Infrastructure:**
+
+        - **Network Reuse**: New VMs automatically join existing VNets and security groups
+
+        - **SSH Key Sharing**: Uses existing SSH keys for consistent access management
+
+        - **Monitoring Integration**: New VMs inherit monitoring configuration from parent MCI
+
+        - **Label Propagation**: Applies MCI-level labels and policies to new VMs
+
+        - **Resource Consistency**: Maintains naming conventions and resource organization
+
+
+        **Scaling Scenarios:**
+
+        - **Horizontal Scaling**: Add more instances to handle increased workload
+
+        - **Multi-Region Expansion**: Deploy VMs in new regions while maintaining MCI cohesion
+
+        - **Provider Diversification**: Add VMs from different cloud providers for redundancy
+
+        - **Workload Specialization**: Deploy VMs with different specifications for specific tasks
+
+
+        **Configuration Requirements:**
+
+        - `specId`: Must specify valid VM specification from system namespace
+
+        - `imageId`: Must specify valid image compatible with target provider/region
+
+        - `name`: Becomes subgroup name; VMs will be named with sequential suffixes
+
+        - `subGroupSize`: Number of identical VMs to create (default: 1)
+
+
+        **Network and Security:**
+
+        - New VMs automatically inherit security group rules from existing MCI
+
+        - Network connectivity to existing VMs is established automatically
+
+        - Firewall rules and access policies are applied consistently
+
+        - SSH access is configured using existing key pairs
+
+
+        **Example Use Cases:**
+
+        - Scale out web tier during traffic spikes
+
+        - Add GPU instances for machine learning workloads
+
+        - Deploy edge nodes in additional geographic regions
+
+        - Add specialized storage or database nodes to existing application stack
+
+
+        **Post-Addition Operations:**
+
+        - New VMs are immediately available for standard MCI operations
+
+        - Can be individually managed or grouped with existing subgroups
+
+        - Monitoring and logging are automatically configured
+
+        - Application deployment and configuration management can proceed immediately'
+    PostInfraNodeGroupScaleOut:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/nodegroup/{subgroupId}
+      description: 'Horizontally scale an existing VM subgroup by adding more identical instances for increased capacity.
+
+        This endpoint provides elastic scaling capabilities for running application tiers:
+
+
+        **Scale-Out Process:**
+
+        1. **SubGroup Validation**: Verifies target subgroup exists and is in scalable state
+
+        2. **Template Replication**: Uses existing VM configuration as template for new instances
+
+        3. **Resource Allocation**: Ensures sufficient CSP quotas and network resources
+
+        4. **Parallel Deployment**: Deploys multiple new VMs simultaneously for faster scaling
+
+        5. **Integration**: Seamlessly integrates new VMs into existing subgroup and MCI
+
+
+        **Configuration Inheritance:**
+
+        - **VM Specifications**: New VMs inherit exact specifications from existing subgroup members
+
+        - **Network Settings**: Automatically placed in same VNet, subnet, and security groups
+
+        - **SSH Keys**: Use same SSH key pairs for consistent access management
+
+        - **Monitoring**: Inherit monitoring agent configuration and policies
+
+        - **Labels and Metadata**: Propagate all labels and metadata from parent subgroup
+
+
+        **Scaling Scenarios:**
+
+        - **Traffic Spikes**: Quickly add capacity during high-demand periods
+
+        - **Seasonal Scaling**: Scale out for predictable demand increases
+
+        - **Performance Optimization**: Add instances to reduce per-VM resource utilization
+
+        - **Geographic Expansion**: Scale existing workloads to handle broader user base
+
+        - **Fault Tolerance**: Increase redundancy by adding more instances
+
+
+        **Intelligent Scaling:**
+
+        - **Sequential Naming**: New VMs follow established naming pattern (e.g., web-4, web-5, web-6)
+
+        - **Load Distribution**: New VMs are distributed optimally across availability zones
+
+        - **Resource Efficiency**: Reuses existing network and security infrastructure
+
+        - **Minimal Disruption**: Scaling occurs without affecting existing VM operations
+
+        - **Consistent Configuration**: Ensures all VMs in subgroup remain homogeneous
+
+
+        **Operational Benefits:**
+
+        - **Zero Downtime**: Existing VMs continue running during scale-out operation
+
+        - **Immediate Availability**: New VMs are ready for traffic as soon as deployment completes
+
+        - **Unified Management**: All VMs (old and new) managed through single subgroup
+
+        - **Policy Consistency**: All scaling and management policies apply uniformly
+
+        - **Monitoring Integration**: New VMs automatically included in existing monitoring dashboards
+
+
+        **Scale-Out Considerations:**
+
+        - **CSP Quotas**: Verifies sufficient instance, network, and storage quotas
+
+        - **Region Capacity**: Ensures target region has capacity for requested instance types
+
+        - **Network Limits**: Validates that VNet can accommodate additional VMs
+
+        - **Cost Impact**: Additional VMs incur proportional CSP billing costs
+
+        - **Application Readiness**: Applications should be designed to handle additional instances
+
+
+        **Post-Scale Operations:**
+
+        - New VMs immediately participate in subgroup operations
+
+        - Can be individually managed while maintaining subgroup membership
+
+        - Support for further scaling operations (scale-out or scale-in)
+
+        - Ready for application deployment and load balancer integration
+
+
+        **Best Practices:**
+
+        - Monitor application performance before and after scaling
+
+        - Ensure load balancers are configured to include new instances
+
+        - Verify application clustering and session management handle new instances
+
+        - Consider database connection limits and other resource constraints'
+    PostInfraNode:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/node
+      description: 'Create and add a group of identical virtual machines (subgroup) to an existing MCI using detailed specifications.
+
+        This endpoint provides precise control over VM configuration and placement within existing infrastructure:
+
+
+        **SubGroup Creation Process:**
+
+        1. **MCI Integration**: Validates target MCI exists and can accommodate new VMs
+
+        2. **Resource Validation**: Verifies all specified resources (specs, images, networks) exist and are accessible
+
+        3. **Homogeneous Deployment**: Creates multiple identical VMs with consistent configuration
+
+        4. **Network Integration**: Integrates new VMs with existing MCI networking and security policies
+
+        5. **Group Management**: Establishes subgroup for collective management and operations
+
+
+        **Detailed Configuration Control:**
+
+        - **Specific Resource References**: Uses exact resource IDs rather than common specifications
+
+        - **Network Placement**: Precise control over VNet, subnet, and security group assignment
+
+        - **Storage Configuration**: Detailed disk configuration including type, size, and performance tiers
+
+        - **Instance Customization**: Full control over VM specifications, images, and metadata
+
+        - **Security Settings**: Explicit security group and SSH key configuration
+
+
+        **SubGroup Benefits:**
+
+        - **Collective Operations**: Perform operations on entire subgroup simultaneously
+
+        - **Homogeneous Scaling**: All VMs in subgroup share identical configuration
+
+        - **Simplified Management**: Single configuration template for multiple VMs
+
+        - **Consistent Naming**: Automatic sequential naming (e.g., web-1, web-2, web-3)
+
+        - **Group Policies**: Apply scaling, monitoring, and lifecycle policies at subgroup level
+
+
+        **Use Cases:**
+
+        - **Application Tiers**: Deploy multiple instances of web servers, application servers, or databases
+
+        - **Load Distribution**: Create multiple identical VMs for load balancing scenarios
+
+        - **High Availability**: Deploy redundant instances across availability zones
+
+        - **Batch Processing**: Create worker nodes for distributed computing workloads
+
+        - **Development Environments**: Provision identical development or testing instances
+
+
+        **Configuration Requirements:**
+
+        - **Resource IDs**: Must specify exact resource identifiers (not common specs)
+
+        - **Network Configuration**: VNet, subnet, and security group must exist and be compatible
+
+        - **SSH Keys**: Must specify valid SSH key pairs for access management
+
+        - **Image Compatibility**: Specified image must be available in target region
+
+        - **Quota Validation**: Sufficient CSP quotas must be available for all requested VMs
+
+
+        **SubGroup Size Considerations:**
+
+        - **Small Groups (1-5 VMs)**: Fast deployment, minimal resource contention
+
+        - **Medium Groups (6-20 VMs)**: Optimized parallel deployment with resource batching
+
+        - **Large Groups (21+ VMs)**: Advanced deployment strategies to avoid CSP rate limits
+
+        - **Resource Limits**: Respects CSP quotas and CB-Tumblebug configuration limits
+
+
+        **Post-Deployment Integration:**
+
+        - SubGroup becomes integral part of parent MCI
+
+        - All VMs inherit MCI-level monitoring and management policies
+
+        - Can be scaled out further or individual VMs can be managed separately
+
+        - Supports all standard CB-Tumblebug VM lifecycle operations'
+    PostInfraNodeSnapshot:
+
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/snapshot
+      description: Snapshot VM and create a Custom Image Object using the Snapshot
+    PostNLB:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb
+      description: Create NLB
+    PostNs:
+      method: post
+      resourcePath: /ns
+      description: Create namespace
+    PostRegisterCSPNativeVM:
+      method: post
+      resourcePath: /ns/{nsId}/registerCspNode
+      description: 'Import and register pre-existing virtual machines from cloud service providers into CB-Tumblebug management.
+
+        This endpoint allows you to bring existing CSP resources under CB-Tumblebug control without recreating them:
+
+
+        **Registration Process:**
+
+        1. **Discovery**: Validates that the specified VM exists in the target CSP
+
+        2. **Metadata Import**: Retrieves VM configuration, network settings, and current status
+
+        3. **Resource Mapping**: Creates CB-Tumblebug resource objects that reference the existing CSP resources
+
+        4. **Status Synchronization**: Aligns CB-Tumblebug status with actual CSP VM state
+
+        5. **Management Integration**: Enables CB-Tumblebug operations on the registered VMs
+
+
+        **Supported VM States:**
+
+        - Running VMs (most common use case)
+
+        - Stopped VMs (will be registered with current state)
+
+        - VMs with attached storage and network interfaces
+
+
+        **Resource Compatibility:**
+
+        - VM must exist in a supported CSP (AWS, Azure, GCP, etc.)
+
+        - Network resources (VPC, subnets, security groups) will be discovered and mapped
+
+        - Storage volumes and attached disks will be registered automatically
+
+        - SSH keys and security configurations will be imported
+
+
+        **Post-Registration Capabilities:**
+
+        - Standard CB-Tumblebug VM lifecycle operations (start, stop, terminate)
+
+        - Monitoring agent installation (if CB-Dragonfly is configured)
+
+        - Command execution and automation
+
+        - Integration with other CB-Tumblebug MCIs
+
+
+        **Important Notes:**
+
+        - Registration does not modify the existing VM configuration
+
+        - Original CSP billing and resource management still applies
+
+        - CB-Tumblebug provides additional management layer and automation
+
+        - Ensure proper CSP credentials and permissions are configured'
+    PostRegisterSubnet:
+      method: post
+      resourcePath: /ns/{nsId}/registerCspResource/vNet/{vNetId}/subnet
+      description: Register Subnet, which was created in CSP
+    PostRegisterVNet:
+      method: post
+      resourcePath: /ns/{nsId}/registerCspResource/vNet
+      description: Register the VNet, which was created in CSP
+    PostScheduleRegisterCspResources:
+      method: post
+      resourcePath: /registerCspResources/schedule
+      description: 'Create a scheduled job to periodically register CSP-native resources (vNet, securityGroup, sshKey, vm) into CB-Tumblebug
+
+
+        **Resource Registration Behavior:**
+
+        This job registers CSP-native resources based on the `connectionName` field:
+
+        - If `connectionName` is specified: Registers resources from the **specified connection only**
+
+        - If `connectionName` is empty or omitted: Registers resources from **all available connections**
+
+
+        **Usage Examples:**
+
+        - Single connection: `{"jobType": "registerCspResources", "nsId": "default", "intervalSeconds": 60, "connectionName": "aws-ap-northeast-2", "mciNamePrefix": "mci-01"}`
+
+        - All connections: `{"jobType": "registerCspResources", "nsId": "default", "intervalSeconds": 60, "connectionName": "", "mciNamePrefix": "mci-all"}` or `{"jobType": "registerCspResources", "nsId": "default", "intervalSeconds": 60, "mciNamePrefix": "mci-all"}`
+
+
+        **Job Status Values:**
+
+        - `Scheduled`: Job is scheduled and waiting for the next execution time
+
+        - `Executing`: Job is currently running the task
+
+        - `Stopped`: Job has been stopped and deleted
+
+
+        **Job Lifecycle:**
+
+        1. Create job (this API) → Status: `Scheduled`, **executes immediately**
+
+        2. First execution starts → Status: `Executing`
+
+        3. Execution completes → Status: `Scheduled` (waits for interval)
+
+        4. After interval → Status: `Executing` (cycles back to step 3)
+
+        5. Pause job → `enabled: false`, Status: `Scheduled` (no execution)
+
+        6. Resume job → `enabled: true`, Status: `Scheduled` (resumes execution)
+
+        7. Delete job → Status: `Stopped`, job removed permanently
+
+
+        **Failure Handling:**
+
+        - Tracks `successCount`, `failureCount`, `consecutiveFailures`
+
+        - Auto-disables after 5 consecutive failures (`autoDisabled: true`)
+
+        - Auto-recovers when next execution succeeds
+
+
+        **Timeout Protection:**
+
+        - Default execution timeout: 30 minutes
+
+        - Jobs exceeding timeout are marked as failed
+
+        - Server restart during execution marks job as interrupted
+
+
+        **Duplicate Prevention:**
+
+        - System checks for existing jobs with same configuration
+
+        - Configuration uniqueness based on: jobType + nsId + connectionName + mciNamePrefix + option + mciFlag
+
+        - Returns 409 Conflict if duplicate job exists with existing job ID'
+    PostSecurityGroup:
+      method: post
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: Create Security Group
+    PostSecurityGroupFromTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/resources/securityGroup/template/{templateId}
+      description: 'Create a new SecurityGroup by applying a SecurityGroup Template.
+
+        The template provides the base SecurityGroup configuration (connectionName, vNetId, firewallRules),
+
+        and the apply request allows overriding the SecurityGroup name and description.
+
+
+        **Override Behavior (Phase 1):**
+
+        - `name` (required): Name for the new SecurityGroup
+
+        - `description` (optional): Overrides the template''s description
+
+        - All other configuration (connectionName, vNetId, firewallRules) comes from the template'
+    PostSecurityGroupTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/template/securityGroup
+      description: 'Create a reusable SecurityGroup Template. Templates store SecurityGroup creation
+
+        request configurations that can be applied later to create SecurityGroups with consistent settings.
+
+
+        **Template Contents:**
+
+        - Connection name (cloud provider and region)
+
+        - vNet ID for the security group
+
+        - Firewall rules (ports, protocol, direction, CIDR)
+
+        - Description
+
+
+        Templates can be created manually with desired SecurityGroup configurations.'
+    PostSiteToSiteVpn:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/vpn
+      description: 'Create a site-to-site VPN
+
+
+        The supported CSP sets are as follows:
+
+
+        - AWS and one of CSPs in Azure, GCP, Alibaba, Tencent, and IBM
+
+
+        - Note: It will take about `15 ~ 45 minutes`.
+
+
+        - Note: A one-time retry is performed to handle transient failures caused by CSP-internal timing issues between dependent resources.
+
+        '
+    PostSpec:
+      method: post
+      resourcePath: /ns/{nsId}/resources/spec
+      description: Register spec
+    PostSpecImagePairReview:
+      method: post
+      resourcePath: /specImagePairReview
+      description: 'Validate whether a spec and image pair is compatible for VM provisioning.
+
+        This lightweight API checks:
+
+        - Spec availability in DB and CSP
+
+        - Image availability in DB and CSP (auto-registers if found in CSP but not in DB)
+
+        - Cost estimation based on spec
+
+
+        **Use Cases:**
+
+        - Quick validation before VM creation
+
+        - Pre-check for dynamic provisioning
+
+        - Verify custom image IDs entered by user'
+    PostSqlDb:
+      method: post
+      resourcePath: /ns/{nsId}/resources/sqlDb
+      description: 'Create a SQL Databases
+
+
+        Supported CSPs: AWS, Azure, GCP, NCP
+
+        - Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral, gcp-asia-northeast3, ncp-kr
+
+
+        - Note - Please check the `requiredCSPResource` property which includes CSP specific values.
+
+
+        - Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/110
+
+        '
+    PostSshKey:
+      method: post
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: Create SSH Key
+    PostSubnet:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet
+      description: Create Subnet
+    PostSystemInfra:
+
+      method: post
+      resourcePath: /systemInfra
+      description: 'Create specialized MCI instances for CB-Tumblebug system operations and infrastructure probing.
+
+        This endpoint provisions system-level infrastructure that supports CB-Tumblebug''s internal functions:
+
+
+        **System MCI Types:**
+
+        - `probe`: Creates lightweight VMs for network connectivity testing and CSP capability discovery
+
+        - `monitor`: Deploys monitoring infrastructure for system health and performance tracking
+
+        - `test`: Provisions test environments for validating CSP integrations and features
+
+
+        **Probe MCI Features:**
+
+        - **Connectivity Testing**: Validates network paths between different CSP regions
+
+        - **Latency Measurement**: Measures inter-region and inter-provider network performance
+
+        - **Feature Discovery**: Tests CSP-specific capabilities and service availability
+
+        - **Resource Validation**: Verifies that CB-Tumblebug can successfully provision resources
+
+
+        **System Namespace:**
+
+        - All system MCIs are created in the special `system` namespace
+
+        - Isolated from user workloads and regular MCI operations
+
+        - Managed automatically by CB-Tumblebug internal processes
+
+        - May be used for background maintenance and monitoring tasks
+
+
+        **Automatic Configuration:**
+
+        - Uses optimized VM specifications for system tasks (typically minimal resources)
+
+        - Automatically selects appropriate regions and providers based on probe requirements
+
+        - Configures necessary network access and security policies
+
+        - Deploys with minimal attack surface and security hardening
+
+
+        **Lifecycle Management:**
+
+        - System MCIs may be automatically created, updated, or destroyed by CB-Tumblebug
+
+        - Typically short-lived for specific system tasks
+
+        - Resource cleanup is handled automatically
+
+        - Status and results are logged for system administrators
+
+
+        **Use Cases:**
+
+        - Infrastructure health checks and validation
+
+        - Performance benchmarking across cloud providers
+
+        - Automated testing of new CSP integrations
+
+        - Network topology discovery and optimization'
+    PostTestStreamResponse:
+      method: post
+      resourcePath: /testStreamResponse
+      description: Receives a number and streams the decrementing number every second until zero
+    PostUtilToDesignNetwork:
+      method: post
+      resourcePath: /util/net/design
+      description: Design a hierarchical network configuration of a VPC network or multi-cloud network consisting of multiple VPC networks
+    PostUtilToDesignVNet:
+      method: post
+      resourcePath: /util/vNet/design
+      description: Design VNet and subnets based on user-friendly properties
+    PostUtilToValidateNetwork:
+      method: post
+      resourcePath: /util/net/validate
+      description: Validate a hierarchical configuration of a VPC network or multi-cloud network consisting of multiple VPC networks
+    PostVNet:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: Create a new VNet
+    PostVNetFromTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet/template/{templateId}
+      description: 'Create a new vNet by applying a vNet Template.
+
+        The template provides the base vNet configuration (connectionName, cidrBlock, subnets),
+
+        and the apply request allows overriding the vNet name and description.
+
+
+        **Override Behavior (Phase 1):**
+
+        - `name` (required): Name for the new vNet
+
+        - `description` (optional): Overrides the template''s description
+
+        - All other configuration (connectionName, cidrBlock, subnets) comes from the template'
+    PostVNetTemplate:
+      method: post
+      resourcePath: /ns/{nsId}/template/vNet
+      description: 'Create a reusable vNet Template. Templates store vNet creation
+
+        request configurations that can be applied later to create vNets with consistent settings.
+
+
+        **Template Contents:**
+
+        - Connection name (cloud provider and region)
+
+        - CIDR block configuration
+
+        - Subnet definitions (names, CIDR blocks, zones)
+
+        - Description
+
+
+        Templates can be created manually with desired vNet configurations.'
+    PostVmDataDisk:
+      method: post
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/dataDisk
+      description: Provisioning (Create and attach) dataDisk
+    PutChangeK8sNodeGroupAutoscaleSize:
+      method: put
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize
+      description: Change a K8sNodeGroup's Autoscale Size
+    PutDataDisk:
+      method: put
+      resourcePath: /ns/{nsId}/resources/dataDisk/{dataDiskId}
+      description: Upsize Data Disk
+    PutGlobalDnsRecord:
+      method: put
+      resourcePath: /resources/globalDns/record
+      description: 'Update (UPSERT) a DNS record for a domain in Route53.
+
+        Supports two routing policies: "simple" (default) and "geoproximity" (location-based).
+
+        Choose exactly one IP source method in ''setBy'':
+
+        1. MCI ID (mciId): Fetch Public IPs of all VMs in the MCI.
+
+        2. Label Selector (labelSelector): Fetch IPs of matching resources.
+
+        3. Manual IP Values (values): Manually provide IP addresses (simple routing only).'
+    PutImage:
+      method: put
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: Update image
+    PutInfraAssociatedSecurityGroups:
+
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/associatedSecurityGroups
+      description: 'Update all Security Groups associated with a given MCI. The firewall rules of all Security Groups will be synchronized to match the requested set.
+
+        Update all Security Groups associated with a given MCI. The firewall rules of all associated Security Groups will be synchronized to match the requested set.
+
+
+        This API will add missing rules and delete extra rules so that each Security Group''s rules become identical to the requested set.
+
+        Only firewall rules are updated; other metadata (name, description, etc.) is not changed.
+
+
+        Usage:
+
+        Use this API to update (synchronize) the firewall rules of all Security Groups associated with the specified MCI. The rules in the request body will become the only rules in each Security Group after the operation.
+
+        - All existing rules not present in the request will be deleted.
+
+        - All rules in the request that do not exist will be added.
+
+        - If a rule exists but differs in CIDR or port range, it will be replaced.
+
+        - Special protocols (ICMP, etc.) are handled in the same way.
+
+
+        Notes:
+
+        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+
+        - The valid port number range is 0 to 65535 (inclusive).
+
+        - "Protocol" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).
+
+        - "Direction" must be either "inbound" or "outbound".
+
+        - "CIDR" is the allowed IP range.
+
+        - All existing rules not in the request (including default ICMP, etc.) will be deleted.
+
+        - Metadata (name, description, etc.) is not changed.'
+    PutInfraDynamicTemplate:
+
+      method: put
+      resourcePath: /ns/{nsId}/template/infra/{templateId}
+      description: Update an existing MCI Dynamic Template.
+    PutMonitorAgentStatusInstalled:
+      method: put
+      resourcePath: /ns/{nsId}/monitoring/status/infra/{mciId}/node/{vmId}
+      description: Set monitoring agent (CB-Dragonfly agent) installation status installed (for Windows VM only)
+    PutNs:
+      method: put
+      resourcePath: /ns/{nsId}
+      description: Update namespace
+    PutScheduleRegisterCspResources:
+      method: put
+      resourcePath: /registerCspResources/schedule/{jobId}
+      description: 'Update the configuration of a scheduled CSP resource registration job (interval, enabled status)
+
+
+        **Updatable Fields:**
+
+        - `intervalSeconds`: Change execution frequency (minimum 10 seconds)
+
+        - `enabled`: Enable (true) or disable (false) the job
+
+
+        **Usage Examples:**
+
+        - Change interval: `{"intervalSeconds": 30}` (30 seconds)
+
+        - Pause job: `{"enabled": false}`
+
+        - Resume job: `{"enabled": true}`
+
+        - Change both: `{"intervalSeconds": 10, "enabled": true}`
+
+
+        **Note:** For simpler pause/resume operations, consider using dedicated `/pause` and `/resume` endpoints'
+    PutScheduleRegisterCspResourcesPause:
+      method: put
+      resourcePath: /registerCspResources/schedule/{jobId}/pause
+      description: 'Temporarily pause a scheduled job without deleting it. The job can be resumed later.
+
+        This sets enabled=false and preserves all job state and execution history.'
+    PutScheduleRegisterCspResourcesResume:
+      method: put
+      resourcePath: /registerCspResources/schedule/{jobId}/resume
+      description: 'Resume a previously paused scheduled job to continue periodic execution.
+
+        This sets enabled=true and restarts the job scheduler.'
+    PutSecurityGroup:
+      method: put
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: 'Update Security Group: Synchronize the firewall rules of the specified Security Group to match the requested list exactly.
+
+        This API will add missing rules and delete extra rules so that the Security Group''s rules become identical to the requested set.
+
+        Only firewall rules are updated; other metadata (name, description, etc.) is not changed.
+
+
+        Usage:
+
+        Use this API to update (synchronize) the firewall rules of a Security Group. The rules in the request body will become the only rules in the Security Group after the operation.
+
+        - All existing rules not present in the request will be deleted.
+
+        - All rules in the request that do not exist will be added.
+
+        - If a rule exists but differs in CIDR or port range, it will be replaced.
+
+        - Special protocols (ICMP, etc.) are handled in the same way.
+
+
+        Notes:
+
+        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+
+        - The valid port number range is 0 to 65535 (inclusive).
+
+        - "Protocol" can be TCP, UDP, ICMP, etc. (as supported by the cloud provider).
+
+        - "Direction" must be either "inbound" or "outbound".
+
+        - "CIDR" is the allowed IP range.
+
+        - All existing rules not in the request (including default ICMP, etc.) will be deleted.
+
+        - Metadata (name, description, etc.) is not changed.'
+    PutSecurityGroupTemplate:
+      method: put
+      resourcePath: /ns/{nsId}/template/securityGroup/{templateId}
+      description: Update an existing SecurityGroup Template.
+    PutSetK8sNodeGroupAutoscaling:
+      method: put
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoscaling
+      description: Set a K8sNodeGroup's Autoscaling On/Off
+    PutSpec:
+      method: put
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: Update spec
+    PutSshKey:
+      method: put
+      resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
+      description: Update SSH Key
+    PutUpgradeK8sCluster:
+      method: put
+      resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/upgrade
+      description: Upgrade a K8sCluster's version
+    PutVNetTemplate:
+      method: put
+      resourcePath: /ns/{nsId}/template/vNet/{templateId}
+      description: Update an existing vNet Template.
+    PutVmDataDisk:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{vmId}/dataDisk
+      description: Attach/Detach available dataDisk
+    RecommendK8sNode:
+      method: post
+      resourcePath: /k8sClusterRecommendNode
+      description: Recommend K8sCluster's Node plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+    RecommendSpec:
+      method: post
+      resourcePath: /recommendSpec
+      description: 'Recommend specs for configuring an infrastructure (filter and priority)
+
+        Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+
+        Get available options by /recommendSpecOptions for filtering and prioritizing
+        specs in RecommendSpec API'
+      requestCoerce:
+        limit: int
+    RecommendSpecOptions:
+      method: get
+      resourcePath: /recommendSpecOptions
+      description: Get available options for filtering and prioritizing specs in RecommendSpec API
+    RecordProvisioningEvent:
+      method: post
+      resourcePath: /provisioning/event
+      description: 'Manually record a provisioning success or failure event for historical tracking and analysis.
+
+        This endpoint allows external systems or manual processes to contribute to provisioning history:
+
+
+        **Use Cases:**
+
+        - **External Provisioning Tools**: Record events from non-CB-Tumblebug provisioning systems
+
+        - **Manual Testing**: Log results from manual deployment tests
+
+        - **Migration**: Import historical data from other systems
+
+        - **Integration**: Connect with CI/CD pipelines for comprehensive tracking
+
+
+        **Event Types:**
+
+        - **Success Events**: Only recorded if previous failures exist for the spec
+
+        - **Failure Events**: Always recorded to build failure pattern database
+
+
+        **Data Quality:**
+
+        - Provide accurate timestamps for proper chronological analysis
+
+        - Include detailed error messages for failure events
+
+        - Use consistent spec ID and image name formats
+
+
+        **Impact on System:**
+
+        - Contributes to risk analysis algorithms
+
+        - Affects future MCI review recommendations
+
+        - Builds historical baseline for reliability metrics'
+    RegisterCredential:
+      method: post
+      resourcePath: /credential
+      description: This API registers credential information using hybrid encryption. The process involves compressing and encrypting sensitive data with AES-256, encrypting the AES key with a 4096-bit RSA public key (retrieved via `GET /credential/publicKey`), and using OAEP padding with SHA-256. All values, including the AES key, must be base64 encoded before sending, and the public key token ID must be included in the request.
+    RegisterCspNativeResources:
+      method: post
+      resourcePath: /registerCspResources
+      description: 'Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to CB-Tumblebug.
+
+
+        **New filtering approach (recommended):**
+
+        - Provider only: Registers resources from all connections of the specified provider
+
+        - Provider + Region: Registers resources from all zones within the region
+
+        - Provider + Region + Zone: Registers resources from specific zone
+
+        - All empty: Registers resources from **all available connections**
+
+
+        **Backward compatibility:**
+
+        - `connectionName` is still supported but deprecated. Use provider/region/zone instead.
+
+
+        **Usage Examples:**
+
+        - All AWS: `{"provider": "aws", "nsId": "default"}`
+
+        - AWS Seoul region: `{"provider": "aws", "region": "ap-northeast-2", "nsId": "default"}`
+
+        - AWS Seoul zone 2a: `{"provider": "aws", "region": "ap-northeast-2", "zone": "ap-northeast-2a", "nsId": "default"}`
+
+        - All connections: `{"nsId": "default", "mciNamePrefix": "mci-all"}`
+
+        - Single connection (deprecated): `{"connectionName": "aws-ap-northeast-2", "nsId": "default"}`'
+    RegisterCspNativeResourcesAll:
+      method: post
+      resourcePath: /registerCspResourcesAll
+      description: '**DEPRECATED**: This endpoint is deprecated. Please use `/registerCspResources` with empty `connectionName` instead.
+
+
+        This endpoint now redirects to `/registerCspResources` for unified API behavior.
+
+
+        **Migration Guide:**
+
+        - Old: `POST /registerCspResourcesAll` with `{"nsId": "default", "mciNamePrefix": "mci-all"}`
+
+        - New: `POST /registerCspResources` with `{"connectionName": "", "nsId": "default", "mciNamePrefix": "mci-all"}`'
+    RemoveBastionNodes:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/bastion/{bastionVmId}
+      description: Remove a bastion VM from all vNets
+    RemoveBastionNodesWithInfra:
+
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/bastion/{bastionMciId}/{bastionVmId}
+      description: Remove a specific cross-MCI bastion from all vNets of the target MCI
+    RemoveBastionNodesWithNs:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/bastion/{bastionNsId}/{bastionMciId}/{bastionVmId}
+      description: Remove a specific cross-namespace bastion from all vNets of the target MCI
+    RemoveLabel:
+      method: delete
+      resourcePath: /label/{labelType}/{uid}/{key}
+      description: Remove a label from a resource identified by its uid
+    RemoveNLBVMs:
+      method: delete
+      resourcePath: /ns/{nsId}/infra/{mciId}/nlb/{nlbId}/node
+      description: Delete VMs from NLB
+    RestDeleteObjectStorage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}
+      description: Delete an object storage (bucket)
+    RetrieveRegionListFromCsp:
+      method: get
+      resourcePath: /regionFromCsp
+      description: RetrieveR all region lists from CSPs
+    SearchImage:
+      method: post
+      resourcePath: /ns/{nsId}/resources/searchImage
+      description: Search image
+    SearchImageOptions:
+      method: get
+      resourcePath: /ns/{nsId}/resources/searchImageOptions
+      description: Get all available options for image search fields
+    SetBastionNodes:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{targetVmId}/bastion/{bastionVmId}
+      description: "Set bastion nodes for a VM"
     Inspectresourcesoverview:
       method: get
       resourcePath: /inspectResourcesOverview
@@ -1949,10 +4479,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}
       description: "Remove a K8sNodeGroup"
-    Getsitesinmci:
-      method: get
-      resourcePath: /ns/{nsId}/mci/{mciId}/site
-      description: "Get sites in MCI"
     Getalldatadisk:
       method: get
       resourcePath: /ns/{nsId}/resources/dataDisk
@@ -1969,36 +4495,200 @@ serviceActions:
       method: post
       resourcePath: /ns/{nsId}/sharedResource
       description: "Create shared resources for MC-Infra"
-    GetCredentialHolderList:
+    ListVNet:
       method: get
-      resourcePath: /credentialHolder
-      description: "List all credential holders derived from registered connection configs."
-    GetAssetsSummary:
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: "List all VNets in a namespace"
+    CreateVNet:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet
+      description: "Create VNet"
+    DeleteVNet:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
+      description: "Delete VNet"
+    ListSecurityGroup:
       method: get
-      resourcePath: /assetsSummary
-      description: "Returns CSP-wise summary of specs and images in DB for a namespace."
-    PostMciSubGroupDynamic:
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: "List all Security Groups in a namespace"
+    CreateSecurityGroup:
       method: post
-      resourcePath: /ns/{nsId}/mci/{mciId}/subGroupDynamic
-      description: "Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management"
-    RecommendSpec:
+      resourcePath: /ns/{nsId}/resources/securityGroup
+      description: "Create Security Group"
+    DeleteSecurityGroup:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/securityGroup/{securityGroupId}
+      description: "Delete Security Group"
+    ListSSHKey:
+      method: get
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: "List all SSH Keys in a namespace"
+    CreateSSHKey:
       method: post
-      resourcePath: /recommendSpec
-      description: "Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234"
-    Postclusterremotecmd:
+      resourcePath: /ns/{nsId}/resources/sshKey
+      description: "Create SSH Key"
+    ListImage:
+      method: get
+      resourcePath: /ns/{nsId}/resources/image
+      description: "List all images in a namespace"
+    RegisterImage:
       method: post
-      resourcePath: /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}
-      description: "Send a command to specified Cluster"
-    Postmcidynamicreview:
+      resourcePath: /ns/{nsId}/resources/image
+      description: "Register image in a namespace"
+    DeleteImage:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/image/{imageId}
+      description: "Delete image"
+    ListSpec:
       method: post
-      resourcePath: /ns/{nsId}/mciDynamicReview
-      description: "Create MCI Dynamically from common spec and image"
+      resourcePath: /ns/{nsId}/resources/filterSpecsByRange
+      description: "List all specs in a namespace"
+    RegisterSpec:
+      method: post
+      resourcePath: /ns/{nsId}/resources/spec
+      description: "Register spec in a namespace"
+    DeleteSpec:
+      method: delete
+      resourcePath: /ns/{nsId}/resources/spec/{specId}
+      description: "Delete spec"
+    SetBastionNodesWithInfra:
 
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{targetVmId}/bastion/{bastionMciId}/{bastionVmId}
+      description: Set bastion nodes for a target VM, specifying a bastion VM that belongs to a different MCI within the same namespace (cross-MCI bastion). This allows, for example, an AWS VM to serve as a bastion for an OpenStack VM.
+    SetBastionNodesWithNs:
+      method: put
+      resourcePath: /ns/{nsId}/infra/{mciId}/node/{targetVmId}/bastion/{bastionNsId}/{bastionMciId}/{bastionVmId}
+      description: Set bastion nodes for a target VM, specifying a bastion VM that belongs to a different namespace and MCI (cross-namespace bastion). This allows, for example, a VM in a shared-services namespace to act as a bastion for VMs in other namespaces.
+    SetObjectStorageCORS:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
+      description: Set CORS configuration of an object storage (bucket)
+    SetObjectStorageCORSLagacy:
+      method: put
+      resourcePath: /resources/objectStorage/{objectStorageName}/cors
+      description: '(To be deprecated) Set CORS configuration of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The CORS configuration must be provided in the request body in XML format.
+
+        - The actual request body should have root element `CORSConfiguration`
+
+
+        **Actual XML Request Body Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <CORSConfiguration>
+
+        <CORSRule>
+
+        <AllowedOrigin>https://example.com</AllowedOrigin>
+
+        <AllowedOrigin>https://app.example.com</AllowedOrigin>
+
+        <AllowedMethod>GET</AllowedMethod>
+
+        <AllowedMethod>PUT</AllowedMethod>
+
+        <AllowedHeader>Content-Type</AllowedHeader>
+
+        <AllowedHeader>Authorization</AllowedHeader>
+
+        <ExposeHeader>ETag</ExposeHeader>
+
+        <MaxAgeSeconds>1800</MaxAgeSeconds>
+
+        </CORSRule>
+
+        <CORSRule>
+
+        <AllowedOrigin>*</AllowedOrigin>
+
+        <AllowedMethod>GET</AllowedMethod>
+
+        <MaxAgeSeconds>300</MaxAgeSeconds>
+
+        </CORSRule>
+
+        </CORSConfiguration>
+
+        ```'
+    SetObjectStorageVersioning:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
+      description: 'Set versioning configuration of an object storage (bucket)
+
+
+        **Note: **
+
+        - Versioning options: "Enabled", "Suspended", "Unversioned"
+
+        '
+    SetObjectStorageVersioningLagacy:
+      method: put
+      resourcePath: /resources/objectStorage/{objectStorageName}/versioning
+      description: '(To be deprecated) Set versioning status of an object storage (bucket)
+
+
+        **Important Notes:**
+
+        - The request body must be XML format with root element `VersioningConfiguration`
+
+        - The `Status` field can be either `Enabled` or `Suspended`
+
+
+        **Request Body Example:**
+
+        ```xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+
+        <Status>Enabled</Status>
+
+        </VersioningConfiguration>
+
+        ```'
+    SetSystemInitialized:
+      method: put
+      resourcePath: /readyz/init
+      description: Set the system initialization status to true. Called by init.py after completing initialization.
+    TestJWTAuth:
+      method: get
+      resourcePath: /auth/test
+      description: Test JWT authentication
+    UnsetSystemInitialized:
+      method: delete
+      resourcePath: /readyz/init
+      description: Reset the system initialization status to false. Useful for re-initialization scenarios.
+    UpdateExistingSpecListByAvailableRegionZones:
+      method: post
+      resourcePath: /ns/{nsId}/updateExistingSpecListByAvailableRegionZones
+      description: Query all specs for a specific provider across all regions, check their availability, and remove specs that are not available in their respective regions
+    UpdateImagesFromAsset:
+      method: post
+      resourcePath: /updateImagesFromAsset
+      description: Update image information based on the cloudimage.csv asset file
+    PostFileAndCmdToInfra:
+
+      method: post
+      resourcePath: /ns/{nsId}/transferFileAndCmd/infra/{infraId}
+      description: 'Transfer a file and execute commands on all nodes in the Infra. (v0.12.9 갱신: /ns/{nsId}/mci/{mciId}/fileAndCmd → /ns/{nsId}/transferFileAndCmd/infra/{infraId})'
   mc-web-console:
     Anycontroller:
       method: post
       resourcePath: /api/{operationId}
       description: AnyController
+    getSetupYamlCheck:
+      method: get
+      resourcePath: /api/admin/setup-yaml-check
+      description: "FR-CLOUD-ADMIN-006-08 — 외부 raw YAML(menu/api) 도달성 확인 BFF endpoint. query: which=menu|api"
     Availabledisktypebyproviderregion:
       method: post
       resourcePath: /api/availabledisktypebyproviderregion
@@ -2023,10 +4713,6 @@ serviceActions:
       method: post
       resourcePath: /api/auth/login
       description: webLogin
-    Webloginrefresh:
-      method: post
-      resourcePath: /api/auth/refresh
-      description: webLoginRefresh
     Weblogout:
       method: post
       resourcePath: /api/auth/logout
@@ -2035,857 +4721,921 @@ serviceActions:
       method: post
       resourcePath: /api/auth/validate
       description: webValidate
-    getSetupYamlCheck:
-      method: get
-      resourcePath: /api/admin/setup-yaml-check
-      description: "외부 raw YAML(menu/api) 도달성 확인 BFF endpoint. query: which=menu|api"
-
   mc-observability:
-    Poststorage:
-      method: post
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage
-      description: ""
-    Getstorages:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage
-      description: ""
-    Putstorage:
-      method: put
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage
-      description: ""
-    Getminingdbtags:
-      method: get
-      resourcePath: /api/o11y/monitoring/miningdb/tag
-      description: ""
-    Gettargetanomalydetectionsettings:
-      method: get
-      resourcePath: /api/o11y/insight/anomaly-detection/settings/nsId/{nsId}/target/{targetId}
-      description: "Fetch the current settings for a specific anomaly detection target."
-    Postanomalydetection:
-      method: post
-      resourcePath: /api/o11y/insight/anomaly-detection/{settingSeq}
-      description: "Request anomaly detection"
-    Getpredictionoptions:
-      method: get
-      resourcePath: /api/o11y/insight/predictions/options
-      description: "Fetch the available target types, metric types, and prediction range options for the prediction API."
-    Gettargetsnsmci:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target
-      description: ""
-    Putitem:
-      method: put
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/item
-      description: ""
-    Postitem:
-      method: post
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/item
-      description: ""
-    Getitems:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/item
-      description: ""
-    Gettriggeralertslackuseralllist:
-      method: get
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/slack
-      description: ""
-    Createtriggeralertslackuser:
-      method: post
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/slack
-      description: ""
-    Deletetriggeralertslackuser:
-      method: delete
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/slack/{seq}
-      description: ""
-    Getminingdbs:
-      method: get
-      resourcePath: /api/o11y/monitoring/miningdb
-      description: ""
-    Putminingdb:
-      method: put
-      resourcePath: /api/o11y/monitoring/miningdb
-      description: ""
-    Gettargets:
-      method: get
-      resourcePath: /api/o11y/monitoring/target
-      description: ""
-    Deletestorage:
-      method: delete
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/storage/{storageSeq}
-      description: ""
-    Deleterequesttriggerpolicy:
-      method: delete
-      resourcePath: /api/o11y/trigger/policy/{policySeq}
-      description: ""
-    Updaterequesttriggerpolicy:
-      method: patch
-      resourcePath: /api/o11y/trigger/policy/{policySeq}
-      description: ""
-    Getreadyz:
+    GetObsReadyz:
       method: get
       resourcePath: /api/o11y/readyz
-      description: ""
-    Getplugins:
+      description: "mc-observability 헬스체크."
+    LogLabelsQuery:
       method: get
-      resourcePath: /api/o11y/monitoring/plugins
-      description: ""
-    Getopensearchlogs:
-      method: post
-      resourcePath: /api/o11y/monitoring/opensearch/logs
-      description: ""
-    Gettriggerpolicyalllist:
+      resourcePath: /api/o11y/log/labels
+      description: Retrieve the list of label keys provided by Loki.
+    LogVolumeQuery:
       method: get
-      resourcePath: /api/o11y/trigger/policy
-      description: ""
-    Createrequesttriggerpolicy:
-      method: post
-      resourcePath: /api/o11y/trigger/policy
-      description: "The values that require Base64 encoding:\ndescription, name, threshold\n"
-    Getallanomalydetectionsettings:
+      resourcePath: /api/o11y/log/log_volumes
+      description: Retrieve log volumes (metric time series data) for the given period.
+    LogRangeQuery:
       method: get
-      resourcePath: /api/o11y/insight/anomaly-detection/settings
-      description: "Fetch the current settings for all anomaly detection targets."
-    Postanomalydetectionsettings:
-      method: post
-      resourcePath: /api/o11y/insight/anomaly-detection/settings
-      description: "Register a target for anomaly detection and automatically schedule detection tasks.  \n(measurememt : field) Relationships are as follows.  \ncpu : usage_idle  \nmem : used_percent\n"
-    Getnss:
-      method: get
-      resourcePath: /api/o11y/monitoring/ns
-      description: ""
-    Getinfluxdbmetrics:
-      method: post
-      resourcePath: /api/o11y/monitoring/influxdb/metric
-      description: ""
-    Putanomalydetectionsettings:
-      method: put
-      resourcePath: /api/o11y/insight/anomaly-detection/settings/{settingSeq}
-      description: "Modify the settings for a specific anomaly detection target, including the monitoring metric and interval."
-    Deleteanomalydetectionsettings:
-      method: delete
-      resourcePath: /api/o11y/insight/anomaly-detection/settings/{settingSeq}
-      description: "Remove a target from anomaly detection, stopping and removing any scheduled tasks."
-    Deleteitem:
-      method: delete
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/item/{itemSeq}
-      description: ""
-    Getinfluxdbmeasurements:
-      method: get
-      resourcePath: /api/o11y/monitoring/influxdb/measurement
-      description: ""
-    Gettriggerhistoryalllist:
-      method: get
-      resourcePath: /api/o11y/trigger/policy/history
-      description: "Base64 Encoded value:  \nname\n"
-    Postprediction:
-      method: post
-      resourcePath: /api/o11y/insight/predictions/nsId/{nsId}/target/{targetId}
-      description: "Predict future metrics (cpu, mem, disk, system) for a given vm or mci group.\n(measurememt : field) Relationships are as follows.  \ncpu : usage_idle  \nmem : used_percent  \ndisk : used_percent  \nsystem : load1\n"
-    Getpredictionhistory:
-      method: get
-      resourcePath: /api/o11y/insight/predictions/nsId/{nsId}/target/{targetId}/history
-      description: "Get previously stored prediction data for a specific vm or mci group."
-    Getinfluxdbtags:
-      method: get
-      resourcePath: /api/o11y/monitoring/influxdb/tag
-      description: ""
-    Getcsp:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}/csp/{measurement}
-      description: ""
-    Puttriggertarget:
-      method: put
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/target
-      description: ""
-    Deletetriggeralertemailuser:
-      method: delete
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/email/{seq}
-      description: ""
-    Getanomalydetectionoptions:
-      method: get
-      resourcePath: /api/o11y/insight/anomaly-detection/options
-      description: "Fetch the available target types, metric types, and interval options for the anomaly detection API."
-    Gettriggertargetalllist:
-      method: get
-      resourcePath: /api/o11y/trigger/policy/target
-      description: ""
-    Gettriggeralertemailuseralllist:
-      method: get
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/email
-      description: ""
-    Createtriggeralertemailuser:
-      method: post
-      resourcePath: /api/o11y/trigger/policy/{policySeq}/alert/email
-      description: ""
-    Getanomalydetectionhistory:
-      method: get
-      resourcePath: /api/o11y/insight/anomaly-detection/nsId/{nsId}/target/{targetId}/history
-      description: "Fetch the results of anomaly detection for a specific target within a given time range."
-    Gettarget:
-      method: get
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}
-      description: ""
-    Puttarget:
-      method: put
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}
-      description: ""
-    Posttarget:
-      method: post
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}
-      description: ""
-    Deletetarget:
-      method: delete
-      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/target/{targetId}
-      description: ""
-    Getminingdbmetrics:
-      method: post
-      resourcePath: /api/o11y/monitoring/miningdb/metric
-      description: ""
-    Getminingdbmeasurements:
-      method: get
-      resourcePath: /api/o11y/monitoring/miningdb/measurement
-      description: ""
-    Getopensearches:
-      method: get
-      resourcePath: /api/o11y/monitoring/opensearch
-      description: ""
-    Getinfluxdbs:
+      resourcePath: /api/o11y/log/query_range
+      description: Retrieve log data for a specific query within a given time range.
+    GetAllInfluxDB:
       method: get
       resourcePath: /api/o11y/monitoring/influxdb
-      description: ""
-
+      description: Retrieve all InfluxDB servers
+    GetPlugins:
+      method: get
+      resourcePath: /api/o11y/monitoring/plugins
+      description: Retrieve plugin list
+    GetAllVMs:
+      method: get
+      resourcePath: /api/o11y/monitoring/vm
+      description: Retrieve all targets
+    GetPaginatedTriggerHistories:
+      method: get
+      resourcePath: /api/o11y/trigger/history
+      description: Get paginated trigger histories
+    GetPaginatedTriggerPolicies:
+      method: get
+      resourcePath: /api/o11y/trigger/policy
+      description: Get paginated trigger policies
+    CreateTriggerPolicy:
+      method: post
+      resourcePath: /api/o11y/trigger/policy
+      description: Create trigger policy
+    GetMeasurementFields:
+      method: get
+      resourcePath: /api/o11y/monitoring/influxdb/measurement
+      queryParams:
+      description: Retrieve InfluxDB measurements
+    GetMeasurementTags:
+      method: get
+      resourcePath: /api/o11y/monitoring/influxdb/tag
+      description: Retrieve InfluxDB tags
+    GetAllAlertRules:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/alert-rules
+      description: Get all alert rules
+    GetAllAlerts:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/alerts
+      description: Get all alerts
+    GetAllContactPoints:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/contact-points
+      description: Get all contact points
+    CheckGrafanaHealthStatus:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/health
+      description: Check grafana health status
+    GetPaginatedAlertTestHistories:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/test-history
+      description: Get paginated alert test histories
+    GetSupportedNotificationChannels:
+      method: get
+      resourcePath: /api/o11y/trigger/noti/channel
+      description: Get supported notification channels
+    GetPaginatedNotificationHistories:
+      method: get
+      resourcePath: /api/o11y/trigger/noti/history
+      description: Get paginated notification histories
+    DeleteTriggerPolicy:
+      method: delete
+      resourcePath: /api/o11y/trigger/policy/{id}
+      description: Delete trigger policy
+    LabelValueQuery:
+      method: get
+      resourcePath: /api/o11y/log/labels/{label}/values
+      description: Retrieve the list of values for a specific label key.
+    GetVMByNsMci:
+      method: get
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm
+      description: Retrieve target list by NS/MCI
+    TestAlertReceiverConnection:
+      method: post
+      resourcePath: /api/o11y/trigger/alert/alert-receiver/test
+      description: Test alert receiver connection
+    SearchAlertsByTitle:
+      method: get
+      resourcePath: /api/o11y/trigger/alert/alerts/search
+      description: Search alerts by title
+    UpdateTriggerHistoryComment:
+      method: put
+      resourcePath: /api/o11y/trigger/history/{id}/comment
+      description: Update trigger history comment
+    UpdateTriggerPolicyNotificationChannels:
+      method: put
+      resourcePath: /api/o11y/trigger/policy/{id}/channel
+      description: Update trigger policy notification channels
+    AddTriggerVM:
+      method: post
+      resourcePath: /api/o11y/trigger/policy/{id}/vm
+      description: Add trigger vm
+    RemoveTriggerVM:
+      method: delete
+      resourcePath: /api/o11y/trigger/policy/{id}/vm
+      description: Remove trigger vm
+    GetMetricsByVMId:
+      method: post
+      resourcePath: /api/o11y/monitoring/influxdb/metric/{nsId}/{mciId}/{vmId}
+      description: Retrieve InfluxDB metrics
+    GetMetricsByNsIdAndMciId:
+      method: post
+      resourcePath: /api/o11y/monitoring/influxdb/metric/{nsId}/{mciId}
+      description: Retrieve InfluxDB metrics
+    GetVM:
+      method: get
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}
+      description: Retrieve single target
+    PostVM:
+      method: post
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}
+      description: Create target (VM)
+    PutVM:
+      method: put
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}
+      description: Update target
+    DeleteVM:
+      method: delete
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}
+      description: Delete target
+    GetMonitoringItems:
+      method: get
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}/item
+      description: Retrieve monitoring item list
+    AddMonitoringItem:
+      method: post
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}/item
+      description: Add monitoring item
+    UpdateMonitoringItem:
+      method: put
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}/item
+      description: Update monitoring item
+    DeleteMonitoringItem:
+      method: delete
+      resourcePath: /api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}/item/{itemSeq}
+      description: Delete monitoring item
+    UpdateAnomalySetting:
+      method: put
+      resourcePath: /api/o11y/insight/anomaly-detection/settings/{settingSeq}
+      description: updateAnomalySetting
+    DeleteAnomalySetting:
+      method: delete
+      resourcePath: /api/o11y/insight/anomaly-detection/settings/{settingSeq}
+      description: deleteAnomalySetting
+    PredictMonitoringDataForMci:
+      method: post
+      resourcePath: /api/o11y/insight/predictions/ns/{nsId}/mci/{mciId}
+      description: predictMonitoringDataForMci
+    PredictMonitoringDataForVm:
+      method: post
+      resourcePath: /api/o11y/insight/predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}
+      description: predictMonitoringDataForVm
+    QueryLogAnalysis:
+      method: post
+      resourcePath: /api/o11y/insight/log-analysis/query
+      description: queryLogAnalysis
+    GetLLMChatSessions:
+      method: get
+      resourcePath: /api/o11y/insight/llm/session
+      description: getLLMChatSessions
+    PostLLMChatSession:
+      method: post
+      resourcePath: /api/o11y/insight/llm/session
+      description: postLLMChatSession
+    DeleteLLMChatSession:
+      method: delete
+      resourcePath: /api/o11y/insight/llm/session
+      description: deleteLLMChatSession
+    GetLLMApiKeys:
+      method: get
+      resourcePath: /api/o11y/insight/llm/api-keys
+      description: getLLMApiKeys
+    PostLLMApiKeys:
+      method: post
+      resourcePath: /api/o11y/insight/llm/api-keys
+      description: postLLMApiKeys
+    PredictAnomalyDetection:
+      method: post
+      resourcePath: /api/o11y/insight/anomaly-detection/{settingSeq}
+      description: predictAnomalyDetection
+    GetAnomalySettings:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/settings
+      description: getAnomalySettings
+    CreateAnomalySetting:
+      method: post
+      resourcePath: /api/o11y/insight/anomaly-detection/settings
+      description: createAnomalySetting
+    QueryAlertAnalysis:
+      method: post
+      resourcePath: /api/o11y/insight/alert-analysis/query
+      description: queryAlertAnalysis
+    GetPredictionOptions:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/options
+      description: getPredictionOptions
+    GetPredictionVMHistory:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}/history
+      description: getPredictionVMHistory
+    GetPredictionMCIHistory:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/ns/{nsId}/mci/{mciId}/history
+      description: getPredictionMCIHistory
+    GetPredictionMeasurements:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/measurement
+      description: getPredictionMeasurements
+    GetPredictionSpecificMeasurement:
+      method: get
+      resourcePath: /api/o11y/insight/predictions/measurement/{measurement}
+      description: getPredictionSpecificMeasurement
+    GetLLMSessionHistory:
+      method: get
+      resourcePath: /api/o11y/insight/llm/session/{sessionId}/history
+      description: getLLMSessionHistory
+    GetLLMModelOptions:
+      method: get
+      resourcePath: /api/o11y/insight/llm/model
+      description: getLLMModelOptions
+    GetAnomalySettingsForMci:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/settings/ns/{nsId}/mci/{mciId}
+      description: getAnomalySettingsForMci
+    GetAnomalySettingsForVm:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/settings/ns/{nsId}/mci/{mciId}/vm/{vmId}
+      description: getAnomalySettingsForVm
+    GetOptions:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/options
+      description: getOptions
+    GetAnomalyDetectionVMHistory:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/ns/{nsId}/mci/{mciId}/vm/{vmId}/history
+      description: getAnomalyDetectionVMHistory
+    GetAnomalyDetectionMCIHistory:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/ns/{nsId}/mci/{mciId}/history
+      description: getAnomalyDetectionMCIHistory
+    GetMeasurements:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/measurement
+      description: getMeasurements
+    GetSpecificMeasurement:
+      method: get
+      resourcePath: /api/o11y/insight/anomaly-detection/measurement/{measurement}
+      description: getSpecificMeasurement
+    DeleteAllLLMChatSessions:
+      method: delete
+      resourcePath: /api/o11y/insight/llm/sessions
+      description: deleteAllLLMChatSessions
+    DeleteLLMApiKeys:
+      method: delete
+      resourcePath: /api/o11y/insight/llm/api-Keys
+      description: deleteLLMApiKeys
   mc-application-manager:
+    GetAppMgrReadyz:
+      method: get
+      resourcePath: /readyz
+      description: "mc-application-manager 헬스체크."
     GetCatalogDetailUsingGET:
       method: get
       resourcePath: /catalog/software/{catalogIdx}
-      description: "software catalog 내용 확인(연결된 정보들까지)"
+      description: software catalog 내용 확인(연결된 정보들까지)
     DeleteCatalogUsingDELETE:
       method: delete
       resourcePath: /catalog/software/{catalogIdx}
-      description: "software catalog 삭제"
+      description: software catalog 삭제
     CheckConnectionUsingPOST:
       method: post
       resourcePath: /oss/connection-check
-      description: ""
+      description: ''
     CreateComponentByTextUsingPOST:
       method: post
       resourcePath: /oss/v1/components/{module}/create/{name}/text
-      description: ""
+      description: ''
     DeleteRepositoryUsingDELETE:
       method: delete
       resourcePath: /oss/v1/repositories/{module}/delete/{name}
-      description: ""
+      description: ''
     UpdateRepositoryUsingPUT:
       method: put
       resourcePath: /oss/v1/repositories/{module}/update
-      description: ""
+      description: ''
     GenerateDeploymentYamlUsingPOST:
       method: post
       resourcePath: /yaml/deployment
-      description: ""
+      description: ''
     GeneratePodYamlUsingPOST:
       method: post
       resourcePath: /yaml/pod
-      description: ""
+      description: ''
     IsOssInfoDuplicatedUsingGET:
       method: get
       resourcePath: /oss/duplicate
-      description: ""
+      description: ''
     CreateComponentUsingPOST:
       method: post
       resourcePath: /oss/v1/components/{module}/create/{name}
-      description: ""
+      description: ''
     GetRepositoryListUsingGET:
       method: get
       resourcePath: /oss/v1/repositories/{module}/list
-      description: ""
+      description: ''
     DeleteOssTypeUsingDELETE:
       method: delete
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     UpdateOssTypeUsingPATCH:
       method: patch
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     DetailOssTypeUsingGET:
       method: get
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     GetRepositoryUsingGET:
       method: get
       resourcePath: /repository/{repositoryName}
-      description: ""
+      description: ''
     InsertRepositoryUsingPOST:
       method: post
       resourcePath: /repository/{repositoryName}
-      description: ""
+      description: ''
     OpenapiJsonUsingGET:
       method: get
       resourcePath: /v3/api-docs
-      description: ""
+      description: ''
     SaveManifestUsingGET:
       method: get
       resourcePath: /manifest/download/{manifestIdx}
-      description: ""
+      description: ''
     DeleteComponentUsingDELETE:
       method: delete
       resourcePath: /oss/v1/components/{module}/delete/{id}
-      description: ""
+      description: ''
     GenerateConfigmapYamlUsingPOST:
       method: post
       resourcePath: /yaml/configmap
-      description: ""
+      description: ''
     GetManifestUsingGET:
       method: get
       resourcePath: /manifest/
-      description: ""
+      description: ''
     CreateManifestUsingPOST:
       method: post
       resourcePath: /manifest/
-      description: ""
+      description: ''
     UpdateManifestUsingPUT:
       method: put
       resourcePath: /manifest/
-      description: ""
+      description: ''
     GetManifestDetailUsingGET:
       method: get
       resourcePath: /manifest/{manifestIdx}
-      description: ""
+      description: ''
     UpdateManifestUsingDELETE:
       method: delete
       resourcePath: /manifest/{manifestIdx}
-      description: ""
+      description: ''
     GetOssListUsingGET_1:
       method: get
       resourcePath: /oss/list
-      description: ""
+      description: ''
     GetRepositoryDetailByNameUsingGET:
       method: get
       resourcePath: /oss/v1/repositories/{module}/detail/{name}
-      description: ""
+      description: ''
     RegistOssTypeUsingPOST:
       method: post
       resourcePath: /ossType
-      description: ""
+      description: ''
     GetRepositoryFileUsingGET:
       method: get
       resourcePath: /repository/file/{filename}
-      description: ""
+      description: ''
     DeleteRepositoryFileUsingDELETE:
       method: delete
       resourcePath: /repository/file/{filename}
-      description: ""
+      description: ''
     OpenapiJsonUsingGET_1:
       method: get
       resourcePath: /v3/api-docs/swagger-config
-      description: ""
+      description: ''
     GetCatalogListUsingGET:
       method: get
       resourcePath: /catalog/software/
-      description: "software catalog 리스트 불러오기"
+      description: software catalog 리스트 불러오기
     CreateCatalogUsingPOST:
       method: post
       resourcePath: /catalog/software/
-      description: "software catalog 등록"
+      description: software catalog 등록
     UpdateCatalogUsingPUT:
       method: put
       resourcePath: /catalog/software/
-      description: "software catalog 수정"
+      description: software catalog 수정
     DeleteCatalogRefWorkflowUsingDELETE:
       method: delete
       resourcePath: /catalog/software/ref/{catalogIdx}/{catalogRefIdx}
-      description: ""
+      description: ''
     GetComponentDetailByNameUsingGET:
       method: get
       resourcePath: /oss/v1/components/{module}/detail/{id}
-      description: ""
+      description: ''
     GenerateHPAYamlUsingPOST:
       method: post
       resourcePath: /yaml/hpa
-      description: ""
+      description: ''
     ExecWorkflowUsingPOST:
       method: post
       resourcePath: /catalog/software/ref/workflow
-      description: ""
+      description: ''
     GetCatalogReferenceUsingGET:
       method: get
       resourcePath: /catalog/software/ref/{catalogIdx}
-      description: ""
+      description: ''
     CreateCatalogRefUsingPOST:
       method: post
       resourcePath: /catalog/software/ref/{catalogIdx}
-      description: "software catalog 관련정보 등록(webpage, workflow 등)"
+      description: software catalog 관련정보 등록(webpage, workflow 등)
     GetManifestDetailTxtUsingGET:
       method: get
       resourcePath: /manifest/{manifestIdx}/txt
-      description: ""
+      description: ''
     DetailOssUsingGET:
       method: get
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     DeleteOssUsingDELETE:
       method: delete
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     UpdateOssUsingPATCH:
       method: patch
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     GetOssTypeListUsingGET:
       method: get
       resourcePath: /ossType/list
-      description: ""
+      description: ''
     GetDockerHubListUsingGET:
       method: get
       resourcePath: /search/dockerhub/{keyword}
-      description: ""
+      description: ''
     GenerateServiceYamlUsingPOST:
       method: post
       resourcePath: /yaml/service
-      description: ""
+      description: ''
     ErrorHtmlUsingHEAD:
       method: head
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingPOST:
       method: post
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingPUT:
       method: put
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingDELETE:
       method: delete
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingOPTIONS:
       method: options
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingPATCH:
       method: patch
       resourcePath: /error
-      description: ""
+      description: ''
     ErrorHtmlUsingGET:
       method: get
       resourcePath: /error
-      description: ""
+      description: ''
     RegistOssUsingPOST:
       method: post
       resourcePath: /oss
-      description: ""
+      description: ''
     GetOssListUsingGET:
       method: get
       resourcePath: /oss/list/{ossTypeName}
-      description: ""
+      description: ''
     UploadFilesUsingPOST:
       method: post
       resourcePath: /repository/file/
-      description: "file upload"
+      description: file upload
     RedirectToUiUsingGET:
       method: get
       resourcePath: /swagger-ui.html
-      description: ""
+      description: ''
     OpenapiYamlUsingGET:
       method: get
       resourcePath: /v3/api-docs.yaml
-      description: ""
+      description: ''
     GetComponentListUsingGET:
       method: get
       resourcePath: /oss/v1/components/{module}/list/{name}
-      description: ""
+      description: ''
     CreateRepositoryUsingPOST:
       method: post
       resourcePath: /oss/v1/repositories/{module}/create
-      description: ""
+      description: ''
     CreateRepositoryUsingPOST_1:
       method: post
       resourcePath: /repository/
-      description: ""
+      description: ''
     UpdateRepositoryUsingPUT_1:
       method: put
       resourcePath: /repository/
-      description: ""
+      description: ''
     DeleteRepositoryUsingDELETE_1:
       method: delete
       resourcePath: /repository/
-      description: ""
+      description: ''
     GetRepositoryListUsingGET_1:
       method: get
       resourcePath: /repository/
-      description: ""
+      description: ''
     GetArtifactHubListUsingGET:
       method: get
       resourcePath: /search/artifacthub/{keyword}
-      description: ""
-
+      description: ''
   mc-workflow-manager:
+    GetWorkflowReadyz:
+      method: get
+      resourcePath: /readyz
+      description: "mc-workflow-manager 헬스체크."
     IsWorkflowNameDuplicatedUsingGET:
       method: get
       resourcePath: /workflow/name/duplicate
-      description: ""
+      description: ''
     GetWorkflowParamListUsingGET:
       method: get
       resourcePath: /workflow/param/list
-      description: ""
+      description: ''
     RegistWorkflowStageUsingPOST:
       method: post
       resourcePath: /workflowStage
-      description: ""
+      description: ''
     DetailEventListenerUsingGET:
       method: get
       resourcePath: /eventlistener/{eventListenerIdx}
-      description: ""
+      description: ''
     DeleteEventListnerUsingDELETE:
       method: delete
       resourcePath: /eventlistener/{eventListenerIdx}
-      description: ""
+      description: ''
     UpdateEventListnerUsingPATCH:
       method: patch
       resourcePath: /eventlistener/{eventListenerIdx}
-      description: ""
+      description: ''
     DetailOssTypeUsingGET:
       method: get
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     DeleteOssTypeUsingDELETE:
       method: delete
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     UpdateOssTypeUsingPATCH:
       method: patch
       resourcePath: /ossType/{ossTypeIdx}
-      description: ""
+      description: ''
     OpenapiYamlUsingGET:
       method: get
       resourcePath: /v3/api-docs.yaml
-      description: ""
+      description: ''
     OpenapiJsonUsingGET_1:
       method: get
       resourcePath: /v3/api-docs/swagger-config
-      description: ""
+      description: ''
     GetWorkflowHistoryListUsingGET:
       method: get
       resourcePath: /workflow/history/{workflowIdx}
-      description: ""
+      description: ''
     DetailOssUsingGET:
       method: get
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     DeleteOssUsingDELETE:
       method: delete
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     UpdateOssUsingPATCH:
       method: patch
       resourcePath: /oss/{ossIdx}
-      description: ""
+      description: ''
     RegistOssTypeUsingPOST:
       method: post
       resourcePath: /ossType
-      description: ""
+      description: ''
     OpenapiJsonUsingGET:
       method: get
       resourcePath: /v3/api-docs
-      description: ""
+      description: ''
     RunWorkflowGetUsingGET:
       method: get
       resourcePath: /workflow/run/{workflowIdx}
-      description: ""
+      description: ''
     DetailWorkflowStageUsingGET:
       method: get
       resourcePath: /workflowStage/{workflowStageIdx}
-      description: ""
+      description: ''
     DeleteWorkflowStageUsingDELETE:
       method: delete
       resourcePath: /workflowStage/{workflowStageIdx}
-      description: ""
+      description: ''
     UpdateWorkflowStageUsingPATCH:
       method: patch
       resourcePath: /workflowStage/{workflowStageIdx}
-      description: ""
+      description: ''
     GetEventListenerListUsingGET:
       method: get
       resourcePath: /eventlistener/list
-      description: ""
+      description: ''
     RegistWorkflowUsingPOST:
       method: post
       resourcePath: /workflow
-      description: ""
+      description: ''
     GetWorkflowStageListUsingGET:
       method: get
       resourcePath: /workflow/workflowStageList
-      description: ""
+      description: ''
     GetWorkflowUsingGET:
       method: get
       resourcePath: /workflow/{workflowIdx}
-      description: ""
+      description: ''
     DeleteWorkflowUsingDELETE:
       method: delete
       resourcePath: /workflow/{workflowIdx}
-      description: ""
+      description: ''
     UpdateWorkflowUsingPATCH:
       method: patch
       resourcePath: /workflow/{workflowIdx}
-      description: ""
+      description: ''
     GetDefaultWorkflowStageUsingGET:
       method: get
       resourcePath: /workflowStage/default/script/{workflowStageTypeName}
-      description: ""
+      description: ''
     RegistEventListnerUsingPOST:
       method: post
       resourcePath: /eventlistener
-      description: ""
+      description: ''
     CheckConnectionUsingPOST:
       method: post
       resourcePath: /oss/connection-check
-      description: ""
+      description: ''
     GetWorkflowListUsingGET:
       method: get
       resourcePath: /workflow/list
-      description: ""
+      description: ''
     GetWorkflowTemplateUsingGET:
       method: get
       resourcePath: /workflow/template/{workflowName}
-      description: ""
+      description: ''
     RedirectToUiUsingGET:
       method: get
       resourcePath: /swagger-ui.html
-      description: ""
+      description: ''
     RegistWorkflowStageUsingPOST_1:
       method: post
       resourcePath: /workflowStageType
-      description: ""
+      description: ''
     GetWorkflowStageListUsingGET_2:
       method: get
       resourcePath: /workflowStageType/list
-      description: ""
+      description: ''
     GetOssListUsingGET_1:
       method: get
       resourcePath: /oss/list
-      description: ""
+      description: ''
     GetOssTypeListUsingGET:
       method: get
       resourcePath: /ossType/list
-      description: ""
+      description: ''
     IsWorkflowStageNameDuplicatedUsingGET:
       method: get
       resourcePath: /workflowStage/duplicate
-      description: ""
+      description: ''
     DetailWorkflowStageTypeUsingGET:
       method: get
       resourcePath: /workflowStageType/{workflowStageTypeIdx}
-      description: ""
+      description: ''
     DeleteWorkflowStageTypeUsingDELETE:
       method: delete
       resourcePath: /workflowStageType/{workflowStageTypeIdx}
-      description: ""
+      description: ''
     UpdateWorkflowStageTypeUsingPATCH:
       method: patch
       resourcePath: /workflowStageType/{workflowStageTypeIdx}
-      description: ""
+      description: ''
     GetWorkflowStageListUsingGET_1:
       method: get
       resourcePath: /workflowStage/list
-      description: ""
+      description: ''
     RunEventListenerUsingGET:
       method: get
       resourcePath: /eventlistener/run/{eventListenerIdx}
-      description: ""
+      description: ''
     RegistOssUsingPOST:
       method: post
       resourcePath: /oss
-      description: ""
+      description: ''
     IsOssInfoDuplicatedUsingGET:
       method: get
       resourcePath: /oss/duplicate
-      description: ""
+      description: ''
     GetOssListUsingGET:
       method: get
       resourcePath: /oss/list/{ossTypeName}
-      description: ""
+      description: ''
     RunWorkflowPostUsingPOST:
       method: post
       resourcePath: /workflow/run
-      description: ""
-
+      description: ''
   mc-cost-optimizer:
-    GetProjects:
-      method: get
-      resourcePath: /api/v2/getProjects
-      description: "워크스페이스에 속한 프로젝트 목록을 조회합니다."
-    GetUnusedRec:
-      method: post
-      resourcePath: /api/v2/opti/unusedRec
-      description: "이번달 CSP별 요약된 빌링 인보이스를 확인한다."
-    GetSummary:
-      method: post
-      resourcePath: /api/v2/invoice/getSummary
-      description: "CSP별 빌링 인보이스 비용을 날짜별로 확인한다."
-    GetInvoice:
-      method: post
-      resourcePath: /api/v2/invoice/getInvoice
-      description: "이번달 빌링 인보이스 내역을 확인한다."
-    GetBillingBaseInfo:
-      method: post
-      resourcePath: /api/v2/invoice/getBillingBaseInfo
-      description: "이번달 CSP별 요약된 빌링 인보이스를 확인한다."
-    GetTop5Bill:
-      method: post
-      resourcePath: /api/v2/getTop5Bill
-      description: "이번달에 사용한 비용 상위 5개의 리소스와 비용을 확인합니다."
-    GetCurMonthBill:
-      method: post
-      resourcePath: /api/v2/getCurMonthBill
-      description: "지난달 대비 이번달 비용을 확인합니다."
-    GetBillAsset:
-      method: post
-      resourcePath: /api/v2/getBillAsset
-      description: "이번달 사용한 리소스의 unit과 비용을 확인합니다."
-    GetWorkspaces:
-      method: get
-      resourcePath: /api/v2/getWorkspaces
-      description: "워크스페이스 목록을 조회합니다."
     GetCostReadyz:
       method: get
       resourcePath: /api/costopti/be/readyz
       description: "mc-cost-optimizer 헬스체크."
-
+    GetProjects:
+      method: get
+      resourcePath: /api/v2/getProjects
+      description: 워크스페이스에 속한 프로젝트 목록을 조회합니다.
+    GetUnusedRec:
+      method: post
+      resourcePath: /api/v2/opti/unusedRec
+      description: 이번달 CSP별 요약된 빌링 인보이스를 확인한다.
+    GetSummary:
+      method: post
+      resourcePath: /api/v2/invoice/getSummary
+      description: CSP별 빌링 인보이스 비용을 날짜별로 확인한다.
+    GetInvoice:
+      method: post
+      resourcePath: /api/v2/invoice/getInvoice
+      description: 이번달 빌링 인보이스 내역을 확인한다.
+    GetBillingBaseInfo:
+      method: post
+      resourcePath: /api/v2/invoice/getBillingBaseInfo
+      description: 이번달 CSP별 요약된 빌링 인보이스를 확인한다.
+    GetTop5Bill:
+      method: post
+      resourcePath: /api/v2/getTop5Bill
+      description: 이번달에 사용한 비용 상위 5개의 리소스와 비용을 확인합니다.
+    GetCurMonthBill:
+      method: post
+      resourcePath: /api/v2/getCurMonthBill
+      description: 지난달 대비 이번달 비용을 확인합니다.
+    GetBillAsset:
+      method: post
+      resourcePath: /api/v2/getBillAsset
+      description: 이번달 사용한 리소스의 unit과 비용을 확인합니다.
+    GetWorkspaces:
+      method: get
+      resourcePath: /api/v2/getWorkspaces
+      description: 워크스페이스 목록을 조회합니다.
   mc-data-manager:
+    GetDataMgrReadyz:
+      method: get
+      resourcePath: /readyz
+      description: "mc-data-manager 헬스체크."
     GenerateWindows:
       method: post
       resourcePath: /generate/windows
-      description: "Generate test data on on-premise Windows."
+      description: Generate test data on on-premise Windows.
     MigrationDynamodbFirestore:
       method: post
       resourcePath: /migration/dynamodb/firestore
-      description: "Migrate data stored in AWS DynamoDB to Google Cloud Firestore."
+      description: Migrate data stored in AWS DynamoDB to Google Cloud Firestore.
     MigrationLinuxNcp:
       method: post
       resourcePath: /migration/linux/ncp
-      description: "Migrate data stored in a Linux-based system to NCP Object Storage."
+      description: Migrate data stored in a Linux-based system to NCP Object Storage.
     MigrationNcpLinux:
       method: post
       resourcePath: /migration/ncp/linux
-      description: "Migrate data stored in NCP Object Storage to a Linux-based system."
+      description: Migrate data stored in NCP Object Storage to a Linux-based system.
     MigrationNcpWindows:
       method: post
       resourcePath: /migration/ncp/windows
-      description: "Migrate data stored in NCP Object Storage to a Windows-based system."
+      description: Migrate data stored in NCP Object Storage to a Windows-based system.
     MigrationGcpWindows:
       method: post
       resourcePath: /migration/gcp/windows
-      description: "Migrate data stored in GCP Cloud Storage to a Windows-based system."
+      description: Migrate data stored in GCP Cloud Storage to a Windows-based system.
     MigrationLinuxS3:
       method: post
       resourcePath: /migration/linux/s3
-      description: "Migrate data stored in a Linux-based system to AWS S3."
+      description: Migrate data stored in a Linux-based system to AWS S3.
     MigrationNcpS3:
       method: post
       resourcePath: /migration/ncp/s3
-      description: "Migrate data stored in NCP Object Storage to AWS S3."
+      description: Migrate data stored in NCP Object Storage to AWS S3.
     MigrationS3Windows:
       method: post
       resourcePath: /migration/s3/windows
-      description: "Migrate data stored in AWS S3 to a Windows-based system."
+      description: Migrate data stored in AWS S3 to a Windows-based system.
     GenerateDynamodb:
       method: post
       resourcePath: /generate/dynamodb
-      description: "Generate test data on AWS DynamoDB."
+      description: Generate test data on AWS DynamoDB.
     MigrationDynamodbMongodb:
       method: post
       resourcePath: /migration/dynamodb/mongodb
-      description: "Migrate data stored in AWS DynamoDB to Naver Cloud MongoDB."
+      description: Migrate data stored in AWS DynamoDB to Naver Cloud MongoDB.
     MigrationLinuxGcp:
       method: post
       resourcePath: /migration/linux/gcp
-      description: "Migrate data stored in a Linux-based system to GCP Cloud Storage."
+      description: Migrate data stored in a Linux-based system to GCP Cloud Storage.
     MigrationMysql:
       method: post
       resourcePath: /migration/mysql
-      description: "Migrate data from one MySQL database to another MySQL database."
+      description: Migrate data from one MySQL database to another MySQL database.
     MigrationWindowsS3:
       method: post
       resourcePath: /migration/windows/s3
-      description: "Migrate data stored in a Windows-based system to AWS S3."
+      description: Migrate data stored in a Windows-based system to AWS S3.
     GenerateFirestore:
       method: post
       resourcePath: /generate/firestore
-      description: "Generate test data on GCP Firestore."
+      description: Generate test data on GCP Firestore.
     GenerateMongodb:
       method: post
       resourcePath: /generate/mongodb
-      description: "Generate test data on NCP MongoDB."
+      description: Generate test data on NCP MongoDB.
     MigrationFirestoreMongodb:
       method: post
       resourcePath: /migration/firestore/mongodb
-      description: "Migrate data stored in Google Cloud Firestore to Naver Cloud MongoDB."
+      description: Migrate data stored in Google Cloud Firestore to Naver Cloud MongoDB.
     MigrationS3Linux:
       method: post
       resourcePath: /migration/s3/linux
-      description: "Migrate data stored in AWS S3 to a Linux-based system."
+      description: Migrate data stored in AWS S3 to a Linux-based system.
     GenerateGcp:
       method: post
       resourcePath: /generate/gcp
-      description: "Generate test data on GCP Cloud Storage."
+      description: Generate test data on GCP Cloud Storage.
     GenerateMysql:
       method: post
       resourcePath: /generate/mysql
-      description: "Generate test data on MySQL."
+      description: Generate test data on MySQL.
     MigrationFirestoreDynamodb:
       method: post
       resourcePath: /migration/firestore/dynamodb
-      description: "Migrate data stored in Google Cloud Firestore to AWS DynamoDB."
+      description: Migrate data stored in Google Cloud Firestore to AWS DynamoDB.
     MigrationGcpNcp:
       method: post
       resourcePath: /migration/gcp/ncp
-      description: "Migrate data stored in GCP Cloud Storage to NCP Object Storage."
+      description: Migrate data stored in GCP Cloud Storage to NCP Object Storage.
     MigrationNcpGcp:
       method: post
       resourcePath: /migration/ncp/gcp
-      description: "Migrate data stored in NCP Object Storage to GCP Cloud Storage."
+      description: Migrate data stored in NCP Object Storage to GCP Cloud Storage.
     GenerateLinux:
       method: post
       resourcePath: /generate/linux
-      description: "Generate test data on on-premise Linux."
+      description: Generate test data on on-premise Linux.
     GenerateNcp:
       method: post
       resourcePath: /generate/ncp
-      description: "Generate test data on NCP Object Storage."
+      description: Generate test data on NCP Object Storage.
     MigrationGcpS3:
       method: post
       resourcePath: /migration/gcp/s3
-      description: "Migrate data stored in GCP Cloud Storage to AWS S3."
+      description: Migrate data stored in GCP Cloud Storage to AWS S3.
     MigrationMongodbDynamodb:
       method: post
       resourcePath: /migration/mongodb/dynamodb
-      description: "Migrate data stored in Naver Cloud MongoDB to AWS DynamoDB."
+      description: Migrate data stored in Naver Cloud MongoDB to AWS DynamoDB.
     GenerateS3:
       method: post
       resourcePath: /generate/s3
-      description: "Generate test data on AWS S3."
+      description: Generate test data on AWS S3.
     MigrationS3Gcp:
       method: post
       resourcePath: /migration/s3/gcp
-      description: "Migrate data stored in AWS S3 to Google Cloud Storage."
+      description: Migrate data stored in AWS S3 to Google Cloud Storage.
     MigrationS3Ncp:
       method: post
       resourcePath: /migration/s3/ncp
-      description: "Migrate data stored in AWS S3 to Naver Cloud Object Storage."
+      description: Migrate data stored in AWS S3 to Naver Cloud Object Storage.
     MigrationGcpLinux:
       method: post
       resourcePath: /migration/gcp/linux
-      description: "Migrate data stored in GCP Cloud Storage to a Linux-based system."
+      description: Migrate data stored in GCP Cloud Storage to a Linux-based system.
     MigrationMongodbFirestore:
       method: post
       resourcePath: /migration/mongodb/firestore
-      description: "Migrate data stored in Naver Cloud MongoDB to Google Cloud Firestore."
+      description: Migrate data stored in Naver Cloud MongoDB to Google Cloud Firestore.
     MigrationWindowsGcp:
       method: post
       resourcePath: /migration/windows/gcp
-      description: "Migrate data stored in a Windows-based system to GCP Cloud Storage."
+      description: Migrate data stored in a Windows-based system to GCP Cloud Storage.
     MigrationWindowsNcp:
       method: post
       resourcePath: /migration/windows/ncp
-      description: "Migrate data stored in a Windows-based system to NCP Object Storage."
+      description: Migrate data stored in a Windows-based system to NCP Object Storage.


### PR DESCRIPTION
## Summary
mc-web-console의 최신 `conf/api.yaml`을 기준으로 `serviceActions` 섹션을 갱신.

## 변경 내역

| 서비스 | 이전 | 이후 | 비고 |
|---|---|---|---|
| mc-infra-manager | 196 actions | 338 actions | PascalCase 명명 규칙으로 전면 갱신 |
| mc-observability | 53 actions | 68 actions | 전면 교체 |
| mc-iam-manager | 132 actions | 130 actions | assignGroupPlatformRole 등 추가, 구형 4개 제거 |
| mc-application-manager | 66 | 67 | +GetAppMgrReadyz |
| mc-data-manager | 34 | 35 | +GetDataMgrReadyz |
| mc-workflow-manager | 47 | 48 | +GetWorkflowReadyz |
| mc-infra-connector | 149 | 149 | 변경 없음 |
| mc-cost-optimizer | 10 | 10 | 변경 없음 |
