### PR TITLE
fix(docker): mc-observability-influx 헬스체크 start_period 및 interval 조정

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -1359,7 +1359,10 @@ services:
       - ./container-volume/mc-observability/influxdb/influxdb_data:/var/lib/influxdb
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8086/health"]
-      <<: *default-health-check
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 120s
 
   mc-observability-influx-2-init-volumes:
     image: busybox:stable
@@ -1396,7 +1399,10 @@ services:
       - ./container-volume/mc-observability/influxdb/influxdb2_data:/var/lib/influxdb
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8086/health"]
-      <<: *default-health-check
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 120s
 
 ##### Remove annotations if data inquiry is required with chronograf during development phase #####
 #  mc-observability-chronograf:


### PR DESCRIPTION
## Summary

- `mc-observability-influx`, `mc-observability-influx-2` 헬스체크 타이밍 수정

## 문제

첫 설치 시 InfluxDB가 `docker-entrypoint-initdb.d` 스크립트로 DB 초기화를 완료하기 전에 헬스체크 실패로 `unhealthy` 판정되며 설치가 중단됨.

```
dependency failed to start: container mc-observability-influx is unhealthy
exit status 1
```

기존 `*default-health-check` 기준으로 총 **4분**만 허용되어 초기화 시간이 부족했음.

## 수정

다른 observability 서비스(grafana, rabbitmq, loki 등)와 동일한 기준으로 변경:

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| `start_period` | 60s | **120s** |
| `interval` | 1m | **10s** |
| `retries` | 3 | **30** |
| 총 허용 시간 | 4분 | **7분** |

## Changed Files

- `conf/docker/docker-compose.yaml`