### PR TITLE
Use cb-tb latest v0.12.21

### DIFF
--- a/conf/docker/conf/mc-infra-manager/assets/cloudimage.csv
+++ b/conf/docker/conf/mc-infra-manager/assets/cloudimage.csv
@@ -49,3 +49,5 @@ TENCENT,all,centos8.0x86_64,CentOS 8.0,"TKE Node - CentOS 8.0, x86_64 (Beta)",,k
 TENCENT,all,ubuntu20.04x86_64,Ubuntu 20.04,"TKE Node - Ubuntu 20.04, x86_64 (Beta)",,k8s,x86_64,ubuntu20.04x86_64
 TENCENT,all,ubuntu22.04x86_64,Ubuntu 22.04,"TKE Node - Ubuntu 22.04, x86_64",,k8s,x86_64,ubuntu22.04x86_64
 TENCENT,all,redhat7.9x86_64,Red Hat Enterprise Linux 7.9,"TKE Node - Red Hat Enterprise Linux 7.9, x86_64",,k8s,x86_64,redhat7.9x86_64
+ALIBABA,all,AliyunLinux3ContainerOptimized,Alibaba Cloud Linux 3 (Container Optimized),"ACK Node - Alibaba Cloud Linux 3, Container Optimized, cgroup v2, x86_64 (default image type)",,k8s,x86_64,AliyunLinux3ContainerOptimized
+ALIBABA,all,Ubuntu,Ubuntu (Latest),"ACK Node - Ubuntu latest (ACK image_type alias, resolves dynamically), cgroup v2, x86_64",,k8s,x86_64,Ubuntu

--- a/conf/docker/conf/mc-infra-manager/assets/cloudimage_ignore.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/cloudimage_ignore.yaml
@@ -61,3 +61,18 @@ csps:
       - "*sles-12*"                  # SUSE Linux Enterprise 12 — EOL Oct 2024
       - "*sles12*"                   # SUSE Linux Enterprise 12 (no-dash variant)
     regions: {}
+
+  azure:
+    description: "Azure image ignore patterns"
+    # metadata_filters match against key-value pairs in the Azure image metadata.
+    # Unlike name patterns, these check CSP-reported fields directly.
+    metadata_filters:
+      # Hyper-V Generation 1 images are excluded because:
+      #   - Modern Azure VM families (NVads V710, DCas, ECas, etc.) require Gen2.
+      #   - Gen1-only VM specs (Av2 series) are retired from new RI sales Jul 2026,
+      #     with full retirement on Nov 15, 2028.
+      #   - Mixing Gen1 images with Gen2-only VMs causes boot failures at provision time.
+      - key: HyperVGeneration
+        value: V1
+        description: "Hyper-V Generation 1 images — excluded; modern Azure VMs require Gen2"
+    regions: {}

--- a/conf/docker/conf/mc-infra-manager/assets/cloudinfo.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/cloudinfo.yaml
@@ -39,6 +39,8 @@ cloud:
         - ap-northeast-1a
         - ap-northeast-1b
         - ap-northeast-1c
+        - ap-northeast-1d
+        - ap-northeast-1e
       ap-northeast-2:
         description: South Korea (Seoul)
         location:
@@ -67,6 +69,7 @@ cloud:
         - ap-southeast-1a
         - ap-southeast-1b
         - ap-southeast-1c
+        - ap-southeast-1d
       # ap-southeast-2:
       #   description: Australia (Sydney)
       #   location:
@@ -124,6 +127,7 @@ cloud:
         zone:
         - cn-chengdu-a
         - cn-chengdu-b
+        - cn-chengdu-c
       cn-guangzhou:
         description: China (Guangzhou)
         location:
@@ -227,6 +231,7 @@ cloud:
         - cn-wulanchabu-a
         - cn-wulanchabu-b
         - cn-wulanchabu-c
+        - cn-wulanchabu-d
       cn-zhangjiakou:
         description: China (Zhangjiakou)
         location:
@@ -264,6 +269,7 @@ cloud:
           longitude: 55.2962
         zone:
         - me-east-1a
+        - me-east-1b
       us-east-1:
         description: US (Virginia)
         location:
@@ -324,6 +330,7 @@ cloud:
           longitude: 120.9799964
         zone:
         - ap-southeast-6a
+        - ap-southeast-6b
       cn-wuhan-lr:
         description: China (Wuhan - Local Region)
         location:
@@ -340,6 +347,33 @@ cloud:
           longitude: -99.1332
         zone:
         - na-south-1a
+      cn-zhongwei:
+        description: China (Zhongwei)
+        location:
+          display: China (Zhongwei)
+          latitude: 37.5167
+          longitude: 105.1893
+        zone:
+        - cn-zhongwei-a
+        - cn-zhongwei-b
+      ap-southeast-8:
+        description: Malaysia (Johor)
+        location:
+          display: Johor, Malaysia
+          latitude: 1.4927
+          longitude: 103.7414
+        zone:
+        - ap-southeast-8a
+        - ap-southeast-8b
+      eu-west-2:
+        description: France (Paris)
+        location:
+          display: Paris, France
+          latitude: 48.8566
+          longitude: 2.3522
+        zone:
+        - eu-west-2a
+        - eu-west-2b
   aws:
     description: Amazon Web Services
     driver: aws-driver-v1.0.so
@@ -498,16 +532,6 @@ cloud:
         - eu-west-3a
         - eu-west-3b
         - eu-west-3c
-      # me-south-1:
-      #   description: Middle East (Bahrain)
-      #   location:
-      #     display: Middle East (Bahrain)
-      #     latitude: 25.0
-      #     longitude: 49.6
-      #   zone:
-      #   - me-south-1a
-      #   - me-south-1b
-      #   - me-south-1c
       sa-east-1:
         description: South America (Sao Paulo)
         location:
@@ -641,6 +665,66 @@ cloud:
         - ca-west-1a
         - ca-west-1b
         - ca-west-1c
+      ap-east-2:
+        description: Asia Pacific (Taipei)
+        location:
+          display: Taipei, Taiwan
+          latitude: 25.0329694
+          longitude: 121.5654177
+        zone:
+        - ap-east-2a
+        - ap-east-2b
+        - ap-east-2c
+      ap-southeast-5:
+        description: Asia Pacific (Malaysia)
+        location:
+          display: Kuala Lumpur, Malaysia
+          latitude: 3.1390
+          longitude: 101.6869
+        zone:
+        - ap-southeast-5a
+        - ap-southeast-5b
+        - ap-southeast-5c
+      ap-southeast-6:
+        description: Asia Pacific (New Zealand)
+        location:
+          display: Auckland, New Zealand
+          latitude: -36.8485
+          longitude: 174.7633
+        zone:
+        - ap-southeast-6a
+        - ap-southeast-6b
+        - ap-southeast-6c
+      ap-southeast-7:
+        description: Asia Pacific (Thailand)
+        location:
+          display: Bangkok, Thailand
+          latitude: 13.7563
+          longitude: 100.5018
+        zone:
+        - ap-southeast-7a
+        - ap-southeast-7b
+        - ap-southeast-7c
+      mx-central-1:
+        description: Mexico (Central)
+        location:
+          display: Querétaro, Mexico
+          latitude: 20.5887932
+          longitude: -100.3898881
+        zone:
+        - mx-central-1a
+        - mx-central-1b
+        - mx-central-1c
+      me-south-1:
+        description: Middle East (Bahrain)
+        location:
+          display: Middle East (Bahrain)
+          latitude: 25.0
+          longitude: 49.6
+        zone:
+        - me-south-1a
+        - me-south-1b
+        - me-south-1c
   azure:
     description: Microsoft Azure
     driver: azure-driver-v1.0.so
@@ -1125,6 +1209,26 @@ cloud:
         - '1'
         - '2'
         - '3'
+      belgiumcentral:
+        desc: Belgium Central
+        location:
+          display: Brussels, Belgium
+          latitude: 50.8503
+          longitude: 4.3517
+        zone:
+        - '1'
+        - '2'
+        - '3'
+      denmarkeast:
+        desc: Denmark East
+        location:
+          display: Copenhagen, Denmark
+          latitude: 55.6761
+          longitude: 12.5683
+        zone:
+        - '1'
+        - '2'
+        - '3'
       # australiacentral2:
       #  desc: ''
       #  location:
@@ -1275,6 +1379,16 @@ cloud:
         - asia-southeast2-a
         - asia-southeast2-b
         - asia-southeast2-c
+      asia-southeast3:
+        description: Bangkok Thailand
+        location:
+          display: Bangkok, Thailand
+          latitude: 13.7563
+          longitude: 100.5018
+        zone:
+        - asia-southeast3-a
+        - asia-southeast3-b
+        - asia-southeast3-c
       australia-southeast1:
         description: Sydney Australia
         location:
@@ -1619,6 +1733,8 @@ cloud:
   ibm:
     description: IBM Cloud
     driver: ibm-driver-v1.0.so
+    link:
+    - https://cloud.ibm.com/docs/overview?topic=overview-locations
     region:
       au-syd:
         description: Sydney (Australia)
@@ -1730,9 +1846,31 @@ cloud:
         - ca-mon-1
         - ca-mon-2
         - ca-mon-3
+      in-che:
+        description: Chennai - Airtel (India)
+        location:
+          display: Chennai, India
+          latitude: 13.0827
+          longitude: 80.2707
+        zone:
+        - in-che-1
+        - in-che-2
+        - in-che-3
+      in-mum:
+        description: Mumbai - Airtel (India)
+        location:
+          display: Mumbai, India
+          latitude: 19.076
+          longitude: 72.8777
+        zone:
+        - in-mum-1
+        - in-mum-2
+        - in-mum-3
   kt:
     description: KT Cloud (VPC)
     driver: kt-driver-v1.0.so
+    link:
+    - https://manual.cloud.kt.com/kt/
     region:
       KR1:
         id: KR1
@@ -1743,9 +1881,38 @@ cloud:
           longitude: 126.874278
         zone:
         - DX-M1
+      KR-CN:
+        id: KR-CN
+        description: Cheonan (South Korea)
+        location:
+          display: Cheonan (South Korea)
+          latitude: 36.815
+          longitude: 127.1139
+        zone:
+        - DX-Central
+      KR-CJ:
+        id: KR-CJ
+        description: Cheongju (South Korea)
+        location:
+          display: Cheongju (South Korea)
+          latitude: 36.6424
+          longitude: 127.489
+        zone:
+        - DX-DCN-CJ
+      KR-YS:
+        id: KR-YS
+        description: Yongsan - Seoul (South Korea)
+        location:
+          display: Yongsan - Seoul (South Korea)
+          latitude: 37.5326
+          longitude: 126.9907
+        zone:
+        - DX-YS
   ncp:
     description: Naver Cloud Platform (VPC)
     driver: ncp-driver-v1.0.so
+    link:
+    - https://guide.ncloud-docs.com/docs/environment-environmentproducts
     region:
       KR:
         id: KR
@@ -1780,6 +1947,8 @@ cloud:
   nhn:
     description: NHN Cloud
     driver: nhn-driver-v1.0.so
+    link:
+    - https://docs.nhncloud.com/en/nhncloud/en/region-guide/
     region:
       KR1:
         id: KR1
@@ -1811,6 +1980,16 @@ cloud:
         zone:
         - jp-pub-a
         - jp-pub-b
+      KR3:
+        id: KR3
+        description: Gwangju (South Korea)
+        location:
+          display: Gwangju (South Korea)
+          latitude: 35.1595
+          longitude: 126.8526
+        zone:
+        - kr3-pub-a
+        - kr3-pub-b
       # US1:
       #   id: US1
       #   desc: US West (California)
@@ -1850,6 +2029,8 @@ cloud:
   tencent:
     description: Tencent Cloud
     driver: tencent-driver-v1.0.so
+    link:
+    - https://www.tencentcloud.com/document/product/213/6091
     region:
       ap-bangkok:
         description: Bangkok
@@ -1894,6 +2075,7 @@ cloud:
           latitude: 23.12911
           longitude: 113.264385
         zone:
+        - ap-guangzhou-5
         - ap-guangzhou-6
         - ap-guangzhou-7
       ap-hongkong:
@@ -2021,3 +2203,12 @@ cloud:
           longitude: -46.64681
         zone:
         - sa-saopaulo-1
+      me-saudi-arabia:
+        description: Saudi Arabia (Riyadh)
+        location:
+          display: Riyadh, Saudi Arabia
+          latitude: 24.7136
+          longitude: 46.6753
+        zone:
+        - me-saudi-arabia-1
+        - me-saudi-arabia-2

--- a/conf/docker/conf/mc-infra-manager/assets/k8sclusterinfo.yaml
+++ b/conf/docker/conf/mc-infra-manager/assets/k8sclusterinfo.yaml
@@ -51,27 +51,27 @@ k8scluster:
     nodeGroupNamingRule: ^[a-z][a-z0-9]*$
     version:
       - region: [westeurope,westus]
-        available: # Updated: 2025-10-30 (verified with az aks get-versions)
+        available: # Updated: 2026-06-24 (verified with learn.microsoft.com/azure/aks/supported-kubernetes-versions + github.com/Azure/AKS/releases)
+          - name: "1.35"
+            id: "1.35.5"
+          - name: "1.34"
+            id: "1.34.8"
           - name: "1.33"
-            id: "1.33.3"
-          - name: "1.32"
-            id: "1.32.7"
-          - name: "1.31"
-            id: "1.31.11"
-          - name: "1.30"
-            id: "1.30.100"
+            id: "1.33.12"
+          # EOL versions (no longer supported for new cluster creation):
+          # 1.32 EOL: Mar 2026, 1.31 EOL: Nov 1 2025, 1.30 EOL: Aug 22 2025
       - region: [westindia]
         # no available version
       - region: [common]
         available:
+          - name: "1.35"
+            id: "1.35.5"
+          - name: "1.34"
+            id: "1.34.8"
           - name: "1.33"
-            id: "1.33.3"
-          - name: "1.32"
-            id: "1.32.7"
-          - name: "1.31"
-            id: "1.31.11"
-          - name: "1.30"
-            id: "1.30.100"
+            id: "1.33.12"
+          # EOL versions (no longer supported for new cluster creation):
+          # 1.32 EOL: Mar 2026, 1.31 EOL: Nov 1 2025, 1.30 EOL: Aug 22 2025
     rootDisk:
       - region: [common]
         type:
@@ -87,15 +87,15 @@ k8scluster:
     version:
       - region: [common]
         # ref: https://cloud.google.com/kubernetes-engine/docs/release-notes-stable
-        # Updated: 2026-02-19 (latest stable channel versions)
+        # Updated: 2026-06-25 (latest stable channel versions)
         # gcloud container get-server-config --region=asia-northeast3 --format=json | jq '{validMasterVersions, channels: [.channels[] | {channel, defaultVersion, validVersions}]}'
-        available: # stable channel versions as of 2026-02-19 (2026-R7)
+        available: # stable channel versions as of 2026-06-25
+          - name: "1.35"
+            id: "1.35.5-gke.1000004"
           - name: "1.34"
-            id: "1.34.3-gke.1051003"
+            id: "1.34.8-gke.1000000"
           - name: "1.33"
-            id: "1.33.5-gke.2172001"
-          - name: "1.32"
-            id: "1.32.11-gke.1038000"
+            id: "1.33.12-gke.1000000"
       - region: [africa-south1]
         # addnodegroup unavailble
     rootDisk:
@@ -110,6 +110,7 @@ k8scluster:
     nodeGroupsOnCreation: false
     nodeImageDesignation: true
     requiredSubnetCount: 1
+    initialNodeGroupManagedByCluster: true
     version:
       # ServiceUnavailable or NotSupportedSLB
       - region: [me-east-1, cn-zhangjiakou, cn-hangzhou, cn-shenzhen, cn-chengdu, ap-south-1, ap-sourtheast-2]
@@ -159,6 +160,7 @@ k8scluster:
     nodeGroupsOnCreation: false
     nodeImageDesignation: true
     requiredSubnetCount: 1
+    initialNodeGroupManagedByCluster: true
     version:
       # ServiceUnavailable
       - region: [ap-mumbai, eu-moscow, na-toronto]
@@ -186,13 +188,11 @@ k8scluster:
     nodeGroupNamingRule: '^[a-z][a-z0-9-]{1,18}[a-z0-9]$'
     version:
       - region: [common]
-        available:
+        available: # Updated: 2026-06-25 (NCP API confirmed: Available 1.34.3-nks.1, 1.33.4-nks.1)
+          - name: "1.34"
+            id: "1.34.3-nks.1"
           - name: "1.33"
             id: "1.33.4-nks.1"
-          - name: "1.32"
-            id: "1.32.8-nks.1"
-          - name: "1.31"
-            id: "1.31.7-nks.1"
     rootDisk:
       - region: [common]
         type:

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
 ##### MC-INFRA-CONNECTOR #########################################################################################################################
 
   mc-infra-connector:
-    image: cloudbaristaorg/cb-spider:0.12.33
+    image: cloudbaristaorg/cb-spider:0.12.32
     pull_policy: missing
     container_name: mc-infra-connector
     restart: unless-stopped
@@ -56,7 +56,7 @@ services:
 ##### MC-INFRA-MANAGER #########################################################################################################################
 
   mc-infra-manager:
-    image: cloudbaristaorg/cb-tumblebug:0.12.20
+    image: cloudbaristaorg/cb-tumblebug:0.12.21
     container_name: mc-infra-manager
     restart: unless-stopped
     pull_policy: missing
@@ -227,7 +227,7 @@ services:
 
   # CB-MapUI is a Web-based test client (disable it for production use)
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.12.45
+    image: cloudbaristaorg/cb-mapui:0.12.46
     container_name: cb-mapui
     networks:
       - mc-infra-manager-network


### PR DESCRIPTION
최신 안정 버전으로 업데이트합니다. 

  mc-infra-manager:
    image: cloudbaristaorg/cb-tumblebug:0.12.21

  cb-mapui:
    image: cloudbaristaorg/cb-mapui:0.12.46

  mc-infra-connector:
    image: cloudbaristaorg/cb-spider:0.12.32

참고로, cloudbaristaorg/cb-spider:0.12.32 은 
기존에 기입되어 있던 0.12.33 에서 하향하였습니다. cb-spider:0.12.33은 
cb-tumblebug에서 테스트가 완료된 버전이 아니므로, m-cmp에서 사용 불가합니다. cb-tumblebug 에서 테스트된 align 된 버전을 사용하셔야 합니다. (특히 cb-spider:0.12.33에 vm 프로비저닝 관련 리팩토링이 있는 부분이 있으므로, 현재는 정상적인 vm 생성을 보장할 수 없습니다.)

