### PR TITLE
chore: update mc-workflow-manager image to v0.6.0

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -979,7 +979,7 @@ services:
 
 
   mc-workflow-manager:
-    image: cloudbaristaorg/mc-workflow-manager:edge
+    image: cloudbaristaorg/mc-workflow-manager:0.6.0
     pull_policy: always
     container_name: mc-workflow-manager
     platform: linux/amd64


### PR DESCRIPTION
update mc-workflow-manager image to v0.6.0