### PR TITLE
chore(docker): bump mc-iam-manager, mc-web-console-api, mc-web-console-front to v0.6.0

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -242,7 +242,7 @@ services:
 
   mc-iam-manager:
     container_name: mc-iam-manager
-    image: cloudbaristaorg/mc-iam-manager:0.5.4
+    image: cloudbaristaorg/mc-iam-manager:0.6.0
     restart: unless-stopped
     networks:
       - mc-iam-manager-network
@@ -1108,7 +1108,7 @@ services:
             exec docker-entrypoint.sh postgres"
 
   mc-web-console-api:
-    image: cloudbaristaorg/mc-web-console-api:edge
+    image: cloudbaristaorg/mc-web-console-api:0.6.0
     pull_policy: always
     container_name: mc-web-console-api
     platform: linux/amd64
@@ -1152,7 +1152,7 @@ services:
       <<: *default-health-check
 
   mc-web-console-front:
-    image: cloudbaristaorg/mc-web-console-front:edge
+    image: cloudbaristaorg/mc-web-console-front:0.6.0
     pull_policy: always
     container_name: mc-web-console-front
     platform: linux/amd64


### PR DESCRIPTION
## Summary

- `conf/docker/docker-compose.yaml` 이미지 버전을 v0.6.0으로 갱신

## Changes

| 서비스 | 이전 | 변경 |
|--------|------|------|
| `mc-iam-manager` | `0.5.4` | `0.6.0` |
| `mc-web-console-api` | `edge` | `0.6.0` |
| `mc-web-console-front` | `edge` | `0.6.0` |
