### PR TITLE
chore: pin mc-observability component images to v0.6.0

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -1175,7 +1175,7 @@ services:
       <<: *default-health-check
 ##### MC-OBSERVABILITY #########################################################################################################################
   mc-observability-manager:
-    image: cloudbaristaorg/mc-observability:edge
+    image: cloudbaristaorg/mc-observability:v0.6.0
     container_name: mc-observability-manager
     restart: unless-stopped
     networks:
@@ -1215,7 +1215,7 @@ services:
       start_period: 5m
 
   mc-observability-front:
-    image: cloudbaristaorg/mc-observability-front:edge
+    image: cloudbaristaorg/mc-observability-front:v0.6.0
     container_name: mc-observability-front
     restart: unless-stopped
     networks:
@@ -1227,7 +1227,7 @@ services:
         condition: service_started
 
   mc-observability-infra:
-    image: cloudbaristaorg/mc-observability-infra:edge
+    image: cloudbaristaorg/mc-observability-infra:v0.6.0
     container_name: mc-observability-infra
     restart: unless-stopped
     networks:
@@ -1352,7 +1352,7 @@ services:
     init: true
 
   mc-observability-influx:
-    image: cloudbaristaorg/mc-observability-influx:edge
+    image: cloudbaristaorg/mc-observability-influx:v0.6.0
     container_name: mc-observability-influx
     restart: unless-stopped
     networks:
@@ -1394,7 +1394,7 @@ services:
       - mc-observability-network
 
   mc-observability-influx-2:
-    image: cloudbaristaorg/mc-observability-influx:edge
+    image: cloudbaristaorg/mc-observability-influx:v0.6.0
     container_name: mc-observability-influx-2
     restart: unless-stopped
     networks:
@@ -1537,7 +1537,7 @@ services:
     init: true
 
   mc-observability-grafana:
-    image: cloudbaristaorg/mc-observability-grafana:edge
+    image: cloudbaristaorg/mc-observability-grafana:v0.6.0
     container_name: mc-observability-grafana
     restart: unless-stopped
     networks:
@@ -1572,7 +1572,7 @@ services:
         fi
 
   mc-observability-insight:
-    image: cloudbaristaorg/mc-observability-insight:edge
+    image: cloudbaristaorg/mc-observability-insight:v0.6.0
     container_name: mc-observability-insight
     restart: always
     networks:
@@ -1599,7 +1599,7 @@ services:
       start_period: 10s
 
   mc-observability-insight-scheduler:
-    image: cloudbaristaorg/mc-observability-insight-scheduler:edge
+    image: cloudbaristaorg/mc-observability-insight-scheduler:v0.6.0
     container_name: mc-observability-insight-scheduler
     restart: always
     ports:
@@ -1678,7 +1678,7 @@ services:
       - mc-observability-network
 
   mc-observability-mcp-maria:
-    image: cloudbaristaorg/mc-observability-mcp-mariadb:edge
+    image: cloudbaristaorg/mc-observability-mcp-mariadb:v0.6.0
     container_name: mc-observability-mcp-maria
     restart: always
     networks:
@@ -1702,7 +1702,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
 
   mc-observability-mcp-influx:
-    image: cloudbaristaorg/mc-observability-mcp-influxdb:edge
+    image: cloudbaristaorg/mc-observability-mcp-influxdb:v0.6.0
     container_name: mc-observability-mcp-influx
     restart: always
     ports:


### PR DESCRIPTION
## mc-observability
- Upgrade mc-observability related images to new v0.6.0.
- Release notes: https://github.com/m-cmp/mc-observability/releases/tag/v0.6.0