### PR TITLE
Use cb-tumblebug:0.12.23

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
 ##### MC-INFRA-CONNECTOR #########################################################################################################################
 
   mc-infra-connector:
-    image: cloudbaristaorg/cb-spider:0.12.32
+    image: cloudbaristaorg/cb-spider:0.12.33
     pull_policy: missing
     container_name: mc-infra-connector
     restart: unless-stopped
@@ -56,7 +56,7 @@ services:
 ##### MC-INFRA-MANAGER #########################################################################################################################
 
   mc-infra-manager:
-    image: cloudbaristaorg/cb-tumblebug:0.12.22
+    image: cloudbaristaorg/cb-tumblebug:0.12.23
     container_name: mc-infra-manager
     restart: unless-stopped
     pull_policy: missing
@@ -227,7 +227,7 @@ services:
 
   # CB-MapUI is a Web-based test client (disable it for production use)
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.12.47
+    image: cloudbaristaorg/cb-mapui:0.12.48
     container_name: cb-mapui
     networks:
       - mc-infra-manager-network


### PR DESCRIPTION
to add etcd space management.

also upgrades cb-spider (0.12.32→0.12.33) and 
cb-mapui (0.12.47→0.12.48)